### PR TITLE
add binderized examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 xmitgcm: Read MITgcm mds binary files into xarray
 =================================================
 
-|pypi| |Build Status| |codecov| |docs| |DOI|
+|pypi| |Build Status| |Binder| |codecov| |docs| |DOI|
 
 xmitgcm is a python package for reading MITgcm_ binary MDS files into
 xarray_ data structures. By storing data in dask_ arrays, xmitgcm enables
@@ -102,6 +102,8 @@ more details.
 .. |docs| image:: http://readthedocs.org/projects/xmitgcm/badge/?version=stable
    :target: http://xmitgcm.readthedocs.org/en/stable/?badge=stable
    :alt: documentation status
+.. |Binder| image:: http://binder.pangeo.io/badge.svg
+    :target: http://binder.pangeo.io/v2/gh/xgcm/xmitgcm/master
 
 .. _dask: http://dask.pydata.org
 .. _xarray: http://xarray.pydata.org
@@ -111,3 +113,6 @@ more details.
 .. _MITgcm: http://mitgcm.org/public/r2_manual/latest/online_documents/node277.html
 .. _out-of-core: https://en.wikipedia.org/wiki/Out-of-core_algorithm
 .. _Anaconda: https://www.continuum.io/downloads
+.. _pangeo.binder.io: http://binder.pangeo.io/
+
+

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,12 @@
+name: root
+channels:
+  - conda-forge
+dependencies:
+  - python=3.6
+  - xarray
+  - dask
+  - netcdf4
+  - matplotlib
+  - cartopy
+  - pip:
+    - git+https://github.com/xgcm/xmitgcm.git

--- a/example_notebooks/tutorial_read_dataset.ipynb
+++ b/example_notebooks/tutorial_read_dataset.ipynb
@@ -1,0 +1,111 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xmitgcm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get a local copy of test run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# download the llc90 test files for figshare, extract and clean up\n",
+    "!wget 'https://ndownloader.figshare.com/files/14066567'\n",
+    "!tar -xf 14066567\n",
+    "!rm 14066567"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load the full dataset at iteration #8"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The llc90 test case is extracted in the *global_oce_llc90* directory, which contains all grid informations and variables at timesteps 0 and 8.\n",
+    "We can load the content of the various data files and expose them as a xarray dataset with:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = xmitgcm.open_mdsdataset('global_oce_llc90', iters=[8], geometry='llc')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can now apply any xarray function onto the dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds['Eta'].sel(face=4).plot(x='XC', y='YC')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
what about adding some xmitgcm examples one can run in binder?
Here's a first quick and dirty one that could be the beginning of a more complete set of examples.