### PR TITLE
Use cache for listing directories

### DIFF
--- a/ci/environment-py27-xarray0.10.9.yml
+++ b/ci/environment-py27-xarray0.10.9.yml
@@ -6,7 +6,7 @@ dependencies:
   - numpy
   - pytest
   - future
-  - cachetools
   - pip:
+    - cachetools
     - codecov
     - pytest-cov

--- a/ci/environment-py27-xarray0.10.9.yml
+++ b/ci/environment-py27-xarray0.10.9.yml
@@ -6,6 +6,7 @@ dependencies:
   - numpy
   - pytest
   - future
+  - cachetools
   - pip:
     - codecov
     - pytest-cov

--- a/ci/environment-py27-xarray0.11.3.yml
+++ b/ci/environment-py27-xarray0.11.3.yml
@@ -6,7 +6,7 @@ dependencies:
   - numpy
   - pytest
   - future
-  - cachetools
   - pip:
+    - cachetools
     - codecov
     - pytest-cov

--- a/ci/environment-py27-xarray0.11.3.yml
+++ b/ci/environment-py27-xarray0.11.3.yml
@@ -6,6 +6,7 @@ dependencies:
   - numpy
   - pytest
   - future
+  - cachetools
   - pip:
     - codecov
     - pytest-cov

--- a/ci/environment-py27.yml
+++ b/ci/environment-py27.yml
@@ -6,7 +6,7 @@ dependencies:
   - numpy
   - pytest
   - future
-  - cachetools
   - pip:
+    - cachetools
     - codecov
     - pytest-cov

--- a/ci/environment-py27.yml
+++ b/ci/environment-py27.yml
@@ -6,6 +6,7 @@ dependencies:
   - numpy
   - pytest
   - future
+  - cachetools
   - pip:
     - codecov
     - pytest-cov

--- a/ci/environment-py35.yml
+++ b/ci/environment-py35.yml
@@ -6,7 +6,7 @@ dependencies:
   - numpy
   - pytest
   - future
-  - cachetools
   - pip:
+    - cachetools
     - codecov
     - pytest-cov

--- a/ci/environment-py35.yml
+++ b/ci/environment-py35.yml
@@ -6,6 +6,7 @@ dependencies:
   - numpy
   - pytest
   - future
+  - cachetools
   - pip:
     - codecov
     - pytest-cov

--- a/ci/environment-py36-xarray0.10.9.yml
+++ b/ci/environment-py36-xarray0.10.9.yml
@@ -6,7 +6,7 @@ dependencies:
   - numpy
   - pytest
   - future
-  - cachetools
   - pip:
+    - cachetools
     - codecov
     - pytest-cov

--- a/ci/environment-py36-xarray0.10.9.yml
+++ b/ci/environment-py36-xarray0.10.9.yml
@@ -6,6 +6,7 @@ dependencies:
   - numpy
   - pytest
   - future
+  - cachetools
   - pip:
     - codecov
     - pytest-cov

--- a/ci/environment-py36-xarray0.11.3.yml
+++ b/ci/environment-py36-xarray0.11.3.yml
@@ -6,7 +6,7 @@ dependencies:
   - numpy
   - pytest
   - future
-  - cachetools
   - pip:
+    - cachetools
     - codecov
     - pytest-cov

--- a/ci/environment-py36-xarray0.11.3.yml
+++ b/ci/environment-py36-xarray0.11.3.yml
@@ -6,6 +6,7 @@ dependencies:
   - numpy
   - pytest
   - future
+  - cachetools
   - pip:
     - codecov
     - pytest-cov

--- a/ci/environment-py36-xarray0.12.0.yml
+++ b/ci/environment-py36-xarray0.12.0.yml
@@ -9,6 +9,7 @@ dependencies:
   - numpy
   - pytest
   - future
+  - cachetools
   - pip:
     - codecov
     - pytest-cov

--- a/ci/environment-py36-xarray0.12.0.yml
+++ b/ci/environment-py36-xarray0.12.0.yml
@@ -9,7 +9,7 @@ dependencies:
   - numpy
   - pytest
   - future
-  - cachetools
   - pip:
+    - cachetools
     - codecov
     - pytest-cov

--- a/ci/environment-py36-xarraymaster.yml
+++ b/ci/environment-py36-xarraymaster.yml
@@ -8,6 +8,7 @@ dependencies:
   - pytest
   - future
   - zarr
+  - cachetools
   - pip:
     - git+https://github.com/pydata/xarray.git
     - fsspec

--- a/ci/environment-py36-xarraymaster.yml
+++ b/ci/environment-py36-xarraymaster.yml
@@ -8,8 +8,8 @@ dependencies:
   - pytest
   - future
   - zarr
-  - cachetools
   - pip:
+    - cachetools
     - git+https://github.com/pydata/xarray.git
     - fsspec
     - codecov

--- a/ci/environment-py36.yml
+++ b/ci/environment-py36.yml
@@ -9,8 +9,8 @@ dependencies:
   - pytest
   - future
   - zarr
-  - cachetools
   - pip:
+    - cachetools
     - fsspec
     - codecov
     - pytest-cov

--- a/ci/environment-py36.yml
+++ b/ci/environment-py36.yml
@@ -9,6 +9,7 @@ dependencies:
   - pytest
   - future
   - zarr
+  - cachetools
   - pip:
     - fsspec
     - codecov

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ CLASSIFIERS = [
     'Topic :: Scientific/Engineering',
 ]
 
-INSTALL_REQUIRES = ['xarray >= 0.10.1', 'dask >= 0.12']
+INSTALL_REQUIRES = ['xarray >= 0.10.1', 'dask >= 0.12', 'cachetools']
 SETUP_REQUIRES = ['pytest-runner']
 TESTS_REQUIRE = ['pytest >= 2.8', 'coverage']
 

--- a/xmitgcm/file_utils.py
+++ b/xmitgcm/file_utils.py
@@ -24,4 +24,4 @@ def listdir_startsandendswith(path, start, end):
 @cached(cache={})
 def listdir_fnmatch(path, pattern):
     files = listdir(path)
-    return [f for f in files if fnmatch.fnmatch(pattern)]
+    return [f for f in files if fnmatch.fnmatch(f, pattern)]

--- a/xmitgcm/file_utils.py
+++ b/xmitgcm/file_utils.py
@@ -1,27 +1,37 @@
-from cachetools import cached
+import cachetools.func
 import os
 import fnmatch
 
-@cached(cache={})
+cache_maxsize = 100
+cache_ttl = 600 # tem minutes
+
+@cachetools.func.ttl_cache(maxsize=cache_maxsize, ttl=cache_ttl)
 def listdir(path):
     return os.listdir(path)
 
-@cached(cache={})
+@cachetools.func.ttl_cache(maxsize=cache_maxsize, ttl=cache_ttl)
 def listdir_startswith(path, pattern):
     files = listdir(path)
     return [f for f in files if f.startswith(pattern)]
 
-@cached(cache={})
+@cachetools.func.ttl_cache(maxsize=cache_maxsize, ttl=cache_ttl)
 def listdir_endswith(path, pattern):
     files = listdir(path)
     return [f for f in files if f.endswith(pattern)]
 
-@cached(cache={})
+@cachetools.func.ttl_cache(maxsize=cache_maxsize, ttl=cache_ttl)
 def listdir_startsandendswith(path, start, end):
     files = listdir(path)
     return [f for f in files if f.endswith(end) and f.startswith(start)]
 
-@cached(cache={})
+@cachetools.func.ttl_cache(maxsize=cache_maxsize, ttl=cache_ttl)
 def listdir_fnmatch(path, pattern):
     files = listdir(path)
     return [f for f in files if fnmatch.fnmatch(f, pattern)]
+
+def clear_cache():
+    listdir.cache_clear()
+    listdir_startswith.cache_clear()
+    listdir_endswith.cache_clear()
+    listdir_startsandendswith.cache_clear()
+    listdir_fnmatch.cache_clear()

--- a/xmitgcm/file_utils.py
+++ b/xmitgcm/file_utils.py
@@ -1,5 +1,6 @@
 from cachetools import cached
 import os
+import fnmatch
 
 @cached(cache={})
 def listdir(path):
@@ -14,3 +15,13 @@ def listdir_startswith(path, pattern):
 def listdir_endswith(path, pattern):
     files = listdir(path)
     return [f for f in files if f.endswith(pattern)]
+
+@cached(cache={})
+def listdir_startsandendswith(path, start, end):
+    files = listdir(path)
+    return [f for f in files if f.endswith(end) and f.startswith(start)]
+
+@cached(cache={})
+def listdir_fnmatch(path, pattern):
+    files = listdir(path)
+    return [f for f in files if fnmatch.fnmatch(pattern)]

--- a/xmitgcm/file_utils.py
+++ b/xmitgcm/file_utils.py
@@ -1,0 +1,16 @@
+from cachetools import cached
+import os
+
+@cached(cache={})
+def listdir(path):
+    return os.listdir(path)
+
+@cached(cache={})
+def listdir_startswith(path, pattern):
+    files = listdir(path)
+    return [f for f in files if f.startswith(pattern)]
+
+@cached(cache={})
+def listdir_endswith(path, pattern):
+    files = listdir(path)
+    return [f for f in files if f.endswith(pattern)]

--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -29,7 +29,7 @@ from .utils import parse_meta_file, read_mds, parse_available_diagnostics,\
     get_extra_metadata
 
 from .file_utils import listdir, listdir_startswith, listdir_endswith, \
-    listdir_startsandendswith
+    listdir_startsandendswith, listdir_fnmatch
 
 # Python2/3 compatibility
 if (sys.version_info > (3, 0)):
@@ -735,7 +735,7 @@ def _guess_model_horiz_dims(data_dir, is_llc=False):
 
 def _guess_layers(data_dir):
     """Return a dict matching layers suffixes to dimension length."""
-    layers_files = file_startsandendswith(data_dir, 'layers', '.meta'))
+    layers_files = listdir_startsandendswith(data_dir, 'layers', '.meta')
     all_layers = {}
     for fname in layers_files:
         # make sure to exclude filenames such as
@@ -743,7 +743,7 @@ def _guess_layers(data_dir):
         if not re.search('\.\d{10}\.', fname):
             # should turn "foo/bar/layers1RHO.meta" into "1RHO"
             layers_suf = os.path.splitext(os.path.basename(fname))[0][6:]
-            meta = parse_meta_file(fname)
+            meta = parse_meta_file(os.path.join(data_dir, fname))
             Nlayers = meta['dimList'][2][2]
             all_layers[layers_suf] = Nlayers
     return all_layers
@@ -778,7 +778,7 @@ def _get_extra_grid_variables(grid_dir):
        Then return the variable information for each of these"""
     extra_grid = {}
 
-    all_datafiles = files_endswith(grid_dir, '.data'))
+    all_datafiles = listdir_endswith(grid_dir, '.data')
     for f in all_datafiles:
         prefix = os.path.split(f[:-5])[-1]
         # Only consider what we find that matches extra_grid_vars
@@ -872,7 +872,7 @@ def _get_all_iternums(data_dir, file_prefixes=None,
                       file_format='*.??????????.data'):
     """Scan a directory for all iteration number suffixes."""
     iternums = set()
-    all_datafiles = glob(os.path.join(data_dir, file_format))
+    all_datafiles = listdir_fnmatch(data_dir, file_format)
     istart = file_format.find('?')-len(file_format)
     iend = file_format.rfind('?')-len(file_format)+1
     for f in all_datafiles:
@@ -901,7 +901,7 @@ def _get_all_matching_prefixes(data_dir, iternum, file_prefixes=None,
     if iternum is None:
         return []
     prefixes = set()
-    all_datafiles = glob(os.path.join(data_dir, '*.%010d.data' % iternum))
+    all_datafiles = listdir_endswith(data_dir, '.%010d.data' % iternum)
     for f in all_datafiles:
         iternum = int(f[-15:-5])
         prefix = os.path.split(f[:-16])[-1]

--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -28,6 +28,9 @@ from .variables import dimensions, \
 from .utils import parse_meta_file, read_mds, parse_available_diagnostics,\
     get_extra_metadata
 
+from .file_utils import listdir, listdir_startswith, listdir_endswith, \
+    listdir_startsandendswith
+
 # Python2/3 compatibility
 if (sys.version_info > (3, 0)):
     stringtypes = [str]
@@ -39,7 +42,7 @@ try:
     from xarray.core.pycompat import OrderedDict
 except ImportError:
     from collections import OrderedDict
-    
+
 # should we hard code this?
 LLC_NUM_FACES = 13
 LLC_FACE_DIMNAME = 'face'
@@ -732,7 +735,7 @@ def _guess_model_horiz_dims(data_dir, is_llc=False):
 
 def _guess_layers(data_dir):
     """Return a dict matching layers suffixes to dimension length."""
-    layers_files = glob(os.path.join(data_dir, 'layers*.meta'))
+    layers_files = file_startsandendswith(data_dir, 'layers', '.meta'))
     all_layers = {}
     for fname in layers_files:
         # make sure to exclude filenames such as
@@ -775,7 +778,7 @@ def _get_extra_grid_variables(grid_dir):
        Then return the variable information for each of these"""
     extra_grid = {}
 
-    all_datafiles = glob(os.path.join(grid_dir, '*.data'))
+    all_datafiles = files_endswith(grid_dir, '.data'))
     for f in all_datafiles:
         prefix = os.path.split(f[:-5])[-1]
         # Only consider what we find that matches extra_grid_vars
@@ -820,7 +823,7 @@ def _get_all_data_variables(data_dir, grid_dir, layers):
     """"Put all the relevant data metadata into one big dictionary."""
     allvars = [state_variables]
     allvars.append(package_state_variables)
-    
+
     # add others from available_diagnostics.log
     # search in the data dir
     fnameD = os.path.join(data_dir, 'available_diagnostics.log')

--- a/xmitgcm/test/test_file_utils.py
+++ b/xmitgcm/test/test_file_utils.py
@@ -23,7 +23,7 @@ def test_listdir_endswith(directory_with_files):
 
 def test_listdir_startsandendswith(directory_with_files):
     path = str(directory_with_files)
-    assert file_utils.listdir_endswith(path, 'bar', '.meta') == ['bar.0000000001.meta']
+    assert file_utils.listdir_startsandendswith(path, 'bar', '.meta') == ['bar.0000000001.meta']
 
 def test_listdir_fnmatch(directory_with_files):
     path = str(directory_with_files)

--- a/xmitgcm/test/test_file_utils.py
+++ b/xmitgcm/test/test_file_utils.py
@@ -1,0 +1,22 @@
+import pytest
+
+from xmitgcm import file_utils
+
+@pytest.fixture(scope="session")
+def directory_with_files(tmpdir_factory):
+    temppath = tmpdir_factory.mktemp("xmitgcm_test_data")
+    temppath.join('bar.0000000001.meta').ensure(file=True)
+    temppath.join('baz.data').ensure(file=True)
+    return temppath
+
+def test_listdir(directory_with_files):
+    path = str(directory_with_files)
+    assert file_utils.listdir(path) == ['bar.0000000001.meta', 'baz.data']
+
+def test_listdir_startswith(directory_with_files):
+    path = str(directory_with_files)
+    assert file_utils.listdir_startswith(path, 'bar') == ['bar.0000000001.meta']
+
+def test_listdir_endswith(directory_with_files):
+    path = str(directory_with_files)
+    assert file_utils.listdir_endswith(path, '.data') == ['baz.data']

--- a/xmitgcm/test/test_file_utils.py
+++ b/xmitgcm/test/test_file_utils.py
@@ -28,3 +28,6 @@ def test_listdir_startsandendswith(directory_with_files):
 def test_listdir_fnmatch(directory_with_files):
     path = str(directory_with_files)
     assert file_utils.listdir_fnmatch(path, '*.??????????.meta') == ['bar.0000000001.meta']
+
+def test_clear_cache():
+    file_utils.clear_cache()

--- a/xmitgcm/test/test_file_utils.py
+++ b/xmitgcm/test/test_file_utils.py
@@ -20,3 +20,11 @@ def test_listdir_startswith(directory_with_files):
 def test_listdir_endswith(directory_with_files):
     path = str(directory_with_files)
     assert file_utils.listdir_endswith(path, '.data') == ['baz.data']
+
+def test_listdir_startsandendswith(directory_with_files):
+    path = str(directory_with_files)
+    assert file_utils.listdir_endswith(path, 'bar', '.meta') == ['bar.0000000001.meta']
+
+def test_listdir_fnmatch(directory_with_files):
+    path = str(directory_with_files)
+    assert file_utils.listdir_fnmatch(path, '*.??????????.meta') == ['bar.0000000001.meta']

--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -346,6 +346,7 @@ def test_multiple_iters(multidim_mds_datadirs):
     # now hide all the PH and PHL files: should be able to infer prefixes fine
     missing_files = [os.path.basename(f)
                      for f in glob(os.path.join(dirname, 'PH*.0*data'))]
+    print(missing_files)
     with hide_file(dirname, *missing_files):
         ds = xmitgcm.open_mdsdataset(
             dirname, read_grid=False, iters=expected['all_iters'],
@@ -417,7 +418,7 @@ def test_avail_diags_in_grid_dir(mds_datadirs_with_diagnostics):
         ds = xmitgcm.open_mdsdataset(
                 dirname, grid_dir=grid_dir, iters=iters, prefix=[diag_prefix],
                 read_grid=False, geometry=expected['geometry'])
-    
+
     for diagname in expected_diags:
         assert diagname in ds
         if 'mate' in ds[diagname].attrs:

--- a/xmitgcm/test/test_utils.py
+++ b/xmitgcm/test/test_utils.py
@@ -3,14 +3,10 @@ import os
 import numpy as np
 import xarray
 import dask
-from xmitgcm.test.test_xmitgcm_common import hide_file
-from xmitgcm.test.test_xmitgcm_common import file_md5_checksum
-from xmitgcm.test.test_xmitgcm_common import all_mds_datadirs
-from xmitgcm.test.test_xmitgcm_common import mds_datadirs_with_diagnostics
-from xmitgcm.test.test_xmitgcm_common import llc_mds_datadirs
-from xmitgcm.test.test_xmitgcm_common import layers_mds_datadirs
-from xmitgcm.test.test_xmitgcm_common import all_grid_datadirs
-from xmitgcm.test.test_xmitgcm_common import _experiments
+from xmitgcm.test.test_xmitgcm_common import (hide_file, file_md5_checksum,
+    all_mds_datadirs, mds_datadirs_with_diagnostics, llc_mds_datadirs,
+    layers_mds_datadirs, all_grid_datadirs, _experiments)
+from xmitgcm.file_utils import listdir
 
 _xc_meta_content = """ simulation = { 'global_oce_latlon' };
  nDims = [   2 ];
@@ -119,17 +115,19 @@ def test_read_raw_data(tmpdir, dtype):
                 shape[0]*shape[1]*shape[2]*dtype.itemsize), partial_read=True,
                 use_mmap=True)
 
-# a meta test
-
-
+# a meta test of our own utitity funcion
 def test_file_hiding(all_mds_datadirs):
     dirname, _ = all_mds_datadirs
     basenames = ['XC.data', 'XC.meta']
+    listed_files = listdir(dirname)
     for basename in basenames:
         assert os.path.exists(os.path.join(dirname, basename))
+        assert basename in listed_files
     with hide_file(dirname, *basenames):
+        listed_files = listdir(dirname)
         for basename in basenames:
             assert not os.path.exists(os.path.join(dirname, basename))
+            assert basename not in listed_files
     for basename in basenames:
         assert os.path.exists(os.path.join(dirname, basename))
 


### PR DESCRIPTION
Hopefully fixes #148. (Alternative to #162)

All the directory listing and matching is placed in the `file_utils.py` modules. These functions use cachetools to cache their output.

I have not actually tested this on a large archive yet. So far I'm just trying to get the tests to pass. I think I have uncovered some weird properties of the tar archives we are using for test data. I want to see what happens on travis.