### PR TITLE
llcreader: get grid info from portal

### DIFF
--- a/doc/llcreader.rst
+++ b/doc/llcreader.rst
@@ -254,7 +254,7 @@ Get a few vertical levels from some 3D variables::
 
 Note that when vertical levels are subset like this, any vertical coordinate
 associated with dimension `k_p1` will have levels above and below the selected
-`k_levls`, which are at cell center.
+`k_levels`, which are at cell center.
 
 A list of all available variables can be seen as follows::
 

--- a/doc/llcreader.rst
+++ b/doc/llcreader.rst
@@ -98,7 +98,7 @@ By default, all variables and all timesteps are loaded::
   >>> ds = model.get_dataset(k_chunksize=90)
   >>> print(ds)
   <xarray.Dataset>
-  Dimensions:   (face: 13, i: 4320, i_g: 4320, j: 4320, j_g: 4320, k: 90, k_l: 90, k_p1: 90, k_u: 90, time: 9030)
+  Dimensions:   (face: 13, i: 4320, i_g: 4320, j: 4320, j_g: 4320, k: 90, k_l: 90, k_p1: 91, k_u: 90, time: 9030)
   Coordinates:
     * face      (face) int64 0 1 2 3 4 5 6 7 8 9 10 11 12
     * i         (i) int64 0 1 2 3 4 5 6 7 ... 4313 4314 4315 4316 4317 4318 4319
@@ -108,30 +108,54 @@ By default, all variables and all timesteps are loaded::
     * k         (k) int64 0 1 2 3 4 5 6 7 8 9 10 ... 80 81 82 83 84 85 86 87 88 89
     * k_u       (k_u) int64 0 1 2 3 4 5 6 7 8 9 ... 80 81 82 83 84 85 86 87 88 89
     * k_l       (k_l) int64 0 1 2 3 4 5 6 7 8 9 ... 80 81 82 83 84 85 86 87 88 89
-    * k_p1      (k_p1) int64 0 1 2 3 4 5 6 7 8 9 ... 80 81 82 83 84 85 86 87 88 89
+    * k_p1      (k_p1) int64 0 1 2 3 4 5 6 7 8 9 ... 81 82 83 84 85 86 87 88 89 90
       niter     (time) int64 ...
     * time      (time) datetime64[ns] 2011-09-13 ... 2012-09-23T05:00:00
+      drC       (k_p1) >f4 dask.array<chunksize=(91,), meta=np.ndarray>
+      drF       (k) >f4 dask.array<chunksize=(90,), meta=np.ndarray>
+      dxC       (face, j, i_g) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      dxF       (face, j, i) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      dxG       (face, j_g, i) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      dyC       (face, j_g, i) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      dyF       (face, j, i) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      dyG       (face, j, i_g) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      hFacC     (k, face, j, i) float32 dask.array<chunksize=(90, 3, 4320, 4320), meta=np.ndarray>
+      hFacS     (k, face, j_g, i) float32 dask.array<chunksize=(90, 3, 4320, 4320), meta=np.ndarray>
+      hFacW     (k, face, j, i_g) float32 dask.array<chunksize=(90, 3, 4320, 4320), meta=np.ndarray>
+      PHrefC    (k) >f4 dask.array<chunksize=(90,), meta=np.ndarray>
+      PHrefF    (k_p1) >f4 dask.array<chunksize=(91,), meta=np.ndarray>
+      rA        (face, j, i) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      rAs       (face, j_g, i) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      rAw       (face, j, i_g) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      Z         (k) >f4 dask.array<chunksize=(90,), meta=np.ndarray>
+      Zp1       (k_p1) >f4 dask.array<chunksize=(91,), meta=np.ndarray>
+      rhoRef    (k) >f4 dask.array<chunksize=(90,), meta=np.ndarray>
+      XC        (face, j, i) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      YC        (face, j, i) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      Zl        (k_l) >f4 dask.array<chunksize=(90,), meta=np.ndarray>
+      Zu        (k_u) >f4 dask.array<chunksize=(90,), meta=np.ndarray>
   Data variables:
-      Eta       (time, face, j, i) >f4 dask.array<shape=(9030, 13, 4320, 4320), chunksize=(1, 3, 4320, 4320)>
-      KPPhbl    (time, face, j, i) >f4 dask.array<shape=(9030, 13, 4320, 4320), chunksize=(1, 3, 4320, 4320)>
-      oceFWflx  (time, face, j, i) >f4 dask.array<shape=(9030, 13, 4320, 4320), chunksize=(1, 3, 4320, 4320)>
-      oceQnet   (time, face, j, i) >f4 dask.array<shape=(9030, 13, 4320, 4320), chunksize=(1, 3, 4320, 4320)>
-      oceQsw    (time, face, j, i) >f4 dask.array<shape=(9030, 13, 4320, 4320), chunksize=(1, 3, 4320, 4320)>
-      oceSflux  (time, face, j, i) >f4 dask.array<shape=(9030, 13, 4320, 4320), chunksize=(1, 3, 4320, 4320)>
-      oceTAUX   (time, face, j, i_g) >f4 dask.array<shape=(9030, 13, 4320, 4320), chunksize=(1, 3, 4320, 4320)>
-      oceTAUY   (time, face, j_g, i) >f4 dask.array<shape=(9030, 13, 4320, 4320), chunksize=(1, 3, 4320, 4320)>
-      PhiBot    (time, face, j, i) >f4 dask.array<shape=(9030, 13, 4320, 4320), chunksize=(1, 3, 4320, 4320)>
-      Salt      (time, k, face, j, i) >f4 dask.array<shape=(9030, 90, 13, 4320, 4320), chunksize=(1, 90, 3, 4320, 4320)>
-      SIarea    (time, face, j, i) >f4 dask.array<shape=(9030, 13, 4320, 4320), chunksize=(1, 3, 4320, 4320)>
-      SIheff    (time, face, j, i) >f4 dask.array<shape=(9030, 13, 4320, 4320), chunksize=(1, 3, 4320, 4320)>
-      SIhsalt   (time, face, j, i) >f4 dask.array<shape=(9030, 13, 4320, 4320), chunksize=(1, 3, 4320, 4320)>
-      SIhsnow   (time, face, j, i) >f4 dask.array<shape=(9030, 13, 4320, 4320), chunksize=(1, 3, 4320, 4320)>
-      SIuice    (time, face, j, i_g) >f4 dask.array<shape=(9030, 13, 4320, 4320), chunksize=(1, 3, 4320, 4320)>
-      SIvice    (time, face, j_g, i) >f4 dask.array<shape=(9030, 13, 4320, 4320), chunksize=(1, 3, 4320, 4320)>
-      Theta     (time, k, face, j, i) >f4 dask.array<shape=(9030, 90, 13, 4320, 4320), chunksize=(1, 90, 3, 4320, 4320)>
-      U         (time, k, face, j, i_g) >f4 dask.array<shape=(9030, 90, 13, 4320, 4320), chunksize=(1, 90, 3, 4320, 4320)>
-      V         (time, k, face, j_g, i) >f4 dask.array<shape=(9030, 90, 13, 4320, 4320), chunksize=(1, 90, 3, 4320, 4320)>
-      W         (time, k_l, face, j, i) >f4 dask.array<shape=(9030, 90, 13, 4320, 4320), chunksize=(1, 90, 3, 4320, 4320)>
+      Eta       (time, face, j, i) float32 dask.array<chunksize=(1, 3, 4320, 4320), meta=np.ndarray>
+      KPPhbl    (time, face, j, i) float32 dask.array<chunksize=(1, 3, 4320, 4320), meta=np.ndarray>
+      oceFWflx  (time, face, j, i) float32 dask.array<chunksize=(1, 3, 4320, 4320), meta=np.ndarray>
+      oceQnet   (time, face, j, i) float32 dask.array<chunksize=(1, 3, 4320, 4320), meta=np.ndarray>
+      oceQsw    (time, face, j, i) float32 dask.array<chunksize=(1, 3, 4320, 4320), meta=np.ndarray>
+      oceSflux  (time, face, j, i) float32 dask.array<chunksize=(1, 3, 4320, 4320), meta=np.ndarray>
+      oceTAUX   (time, face, j, i_g) float32 dask.array<chunksize=(1, 3, 4320, 4320), meta=np.ndarray>
+      oceTAUY   (time, face, j_g, i) float32 dask.array<chunksize=(1, 3, 4320, 4320), meta=np.ndarray>
+      PhiBot    (time, face, j, i) float32 dask.array<chunksize=(1, 3, 4320, 4320), meta=np.ndarray>
+      Salt      (time, k, face, j, i) float32 dask.array<chunksize=(1, 90, 3, 4320, 4320), meta=np.ndarray>
+      SIarea    (time, face, j, i) float32 dask.array<chunksize=(1, 3, 4320, 4320), meta=np.ndarray>
+      SIheff    (time, face, j, i) float32 dask.array<chunksize=(1, 3, 4320, 4320), meta=np.ndarray>
+      SIhsalt   (time, face, j, i) float32 dask.array<chunksize=(1, 3, 4320, 4320), meta=np.ndarray>
+      SIhsnow   (time, face, j, i) float32 dask.array<chunksize=(1, 3, 4320, 4320), meta=np.ndarray>
+      SIuice    (time, face, j, i_g) float32 dask.array<chunksize=(1, 3, 4320, 4320), meta=np.ndarray>
+      SIvice    (time, face, j_g, i) float32 dask.array<chunksize=(1, 3, 4320, 4320), meta=np.ndarray>
+      Theta     (time, k, face, j, i) float32 dask.array<chunksize=(1, 90, 3, 4320, 4320), meta=np.ndarray>
+      U         (time, k, face, j, i_g) float32 dask.array<chunksize=(1, 90, 3, 4320, 4320), meta=np.ndarray>
+      V         (time, k, face, j_g, i) float32 dask.array<chunksize=(1, 90, 3, 4320, 4320), meta=np.ndarray>
+      W         (time, k_l, face, j, i) float32 dask.array<chunksize=(1, 90, 3, 4320, 4320), meta=np.ndarray>
+
 
 This dataset is useless for computations on a laptop, because the individual
 chunks require nearly 20 GB of memory.
@@ -141,8 +165,9 @@ Get a single 2D variable::
 
   >>> ds = model.get_dataset(varnames=['Eta'])
   >>> print(ds)
+
   <xarray.Dataset>
-  Dimensions:  (face: 13, i: 4320, i_g: 4320, j: 4320, j_g: 4320, k: 90, k_l: 90, k_p1: 90, k_u: 90, time: 9030)
+  Dimensions:  (face: 13, i: 4320, i_g: 4320, j: 4320, j_g: 4320, k: 90, k_l: 90, k_p1: 91, k_u: 90, time: 9030)
   Coordinates:
     * face     (face) int64 0 1 2 3 4 5 6 7 8 9 10 11 12
     * i        (i) int64 0 1 2 3 4 5 6 7 ... 4313 4314 4315 4316 4317 4318 4319
@@ -152,18 +177,42 @@ Get a single 2D variable::
     * k        (k) int64 0 1 2 3 4 5 6 7 8 9 10 ... 80 81 82 83 84 85 86 87 88 89
     * k_u      (k_u) int64 0 1 2 3 4 5 6 7 8 9 ... 80 81 82 83 84 85 86 87 88 89
     * k_l      (k_l) int64 0 1 2 3 4 5 6 7 8 9 ... 80 81 82 83 84 85 86 87 88 89
-    * k_p1     (k_p1) int64 0 1 2 3 4 5 6 7 8 9 ... 80 81 82 83 84 85 86 87 88 89
+    * k_p1     (k_p1) int64 0 1 2 3 4 5 6 7 8 9 ... 81 82 83 84 85 86 87 88 89 90
       niter    (time) int64 ...
     * time     (time) datetime64[ns] 2011-09-13 ... 2012-09-23T05:00:00
+      drC      (k_p1) >f4 dask.array<chunksize=(91,), meta=np.ndarray>
+      drF      (k) >f4 dask.array<chunksize=(90,), meta=np.ndarray>
+      dxC      (face, j, i_g) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      dxF      (face, j, i) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      dxG      (face, j_g, i) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      dyC      (face, j_g, i) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      dyF      (face, j, i) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      dyG      (face, j, i_g) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      hFacC    (k, face, j, i) float32 dask.array<chunksize=(1, 3, 4320, 4320), meta=np.ndarray>
+      hFacS    (k, face, j_g, i) float32 dask.array<chunksize=(1, 3, 4320, 4320), meta=np.ndarray>
+      hFacW    (k, face, j, i_g) float32 dask.array<chunksize=(1, 3, 4320, 4320), meta=np.ndarray>
+      PHrefC   (k) >f4 dask.array<chunksize=(90,), meta=np.ndarray>
+      PHrefF   (k_p1) >f4 dask.array<chunksize=(91,), meta=np.ndarray>
+      rA       (face, j, i) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      rAs      (face, j_g, i) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      rAw      (face, j, i_g) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      Z        (k) >f4 dask.array<chunksize=(90,), meta=np.ndarray>
+      Zp1      (k_p1) >f4 dask.array<chunksize=(91,), meta=np.ndarray>
+      rhoRef   (k) >f4 dask.array<chunksize=(90,), meta=np.ndarray>
+      XC       (face, j, i) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      YC       (face, j, i) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      Zl       (k_l) >f4 dask.array<chunksize=(90,), meta=np.ndarray>
+      Zu       (k_u) >f4 dask.array<chunksize=(90,), meta=np.ndarray>
   Data variables:
-      Eta      (time, face, j, i) >f4 dask.array<shape=(9030, 13, 4320, 4320), chunksize=(1, 3, 4320, 4320)>
+      Eta      (time, face, j, i) float32 dask.array<chunksize=(1, 3, 4320, 4320), meta=np.ndarray>
+
 
 Get a few vertical levels from some 3D variables::
 
   >>> ds = model.get_dataset(varnames=['Salt', 'Theta'], k_levels=[1, 10, 40])
   >>> print(ds)
   <xarray.Dataset>
-  Dimensions:  (face: 13, i: 4320, i_g: 4320, j: 4320, j_g: 4320, k: 3, k_l: 3, k_p1: 3, k_u: 3, time: 9030)
+  Dimensions:  (face: 13, i: 4320, i_g: 4320, j: 4320, j_g: 4320, k: 3, k_l: 3, k_p1: 6, k_u: 3, time: 9030)
   Coordinates:
     * face     (face) int64 0 1 2 3 4 5 6 7 8 9 10 11 12
     * i        (i) int64 0 1 2 3 4 5 6 7 ... 4313 4314 4315 4316 4317 4318 4319
@@ -173,13 +222,39 @@ Get a few vertical levels from some 3D variables::
     * k        (k) int64 1 10 40
     * k_u      (k_u) int64 1 10 40
     * k_l      (k_l) int64 1 10 40
-    * k_p1     (k_p1) int64 1 10 40
+    * k_p1     (k_p1) int64 1 2 10 11 40 41
       niter    (time) int64 ...
     * time     (time) datetime64[ns] 2011-09-13 ... 2012-09-23T05:00:00
+      drC      (k_p1) >f4 dask.array<chunksize=(6,), meta=np.ndarray>
+      drF      (k) >f4 dask.array<chunksize=(3,), meta=np.ndarray>
+      dxC      (face, j, i_g) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      dxF      (face, j, i) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      dxG      (face, j_g, i) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      dyC      (face, j_g, i) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      dyF      (face, j, i) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      dyG      (face, j, i_g) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      hFacC    (k, face, j, i) float32 dask.array<chunksize=(1, 3, 4320, 4320), meta=np.ndarray>
+      hFacS    (k, face, j_g, i) float32 dask.array<chunksize=(1, 3, 4320, 4320), meta=np.ndarray>
+      hFacW    (k, face, j, i_g) float32 dask.array<chunksize=(1, 3, 4320, 4320), meta=np.ndarray>
+      PHrefC   (k) >f4 dask.array<chunksize=(3,), meta=np.ndarray>
+      PHrefF   (k_p1) >f4 dask.array<chunksize=(6,), meta=np.ndarray>
+      rA       (face, j, i) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      rAs      (face, j_g, i) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      rAw      (face, j, i_g) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      Z        (k) >f4 dask.array<chunksize=(3,), meta=np.ndarray>
+      Zp1      (k_p1) >f4 dask.array<chunksize=(6,), meta=np.ndarray>
+      rhoRef   (k) >f4 dask.array<chunksize=(3,), meta=np.ndarray>
+      XC       (face, j, i) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      YC       (face, j, i) float32 dask.array<chunksize=(3, 4320, 4320), meta=np.ndarray>
+      Zl       (k_l) >f4 dask.array<chunksize=(3,), meta=np.ndarray>
+      Zu       (k_u) >f4 dask.array<chunksize=(3,), meta=np.ndarray>
   Data variables:
-      Salt     (time, k, face, j, i) >f4 dask.array<shape=(9030, 3, 13, 4320, 4320), chunksize=(1, 1, 3, 4320, 4320)>
-      Theta    (time, k, face, j, i) >f4 dask.array<shape=(9030, 3, 13, 4320, 4320), chunksize=(1, 1, 3, 4320, 4320)>
+      Salt     (time, k, face, j, i) float32 dask.array<chunksize=(1, 1, 3, 4320, 4320), meta=np.ndarray>
+      Theta    (time, k, face, j, i) float32 dask.array<chunksize=(1, 1, 3, 4320, 4320), meta=np.ndarray>
 
+Note that when vertical levels are subset like this, any vertical coordinate
+associated with dimension `k_p1` will have levels above and below the selected
+`k_levls`, which are at cell center.
 
 A list of all available variables can be seen as follows::
 

--- a/xmitgcm/llcreader/known_models.py
+++ b/xmitgcm/llcreader/known_models.py
@@ -42,8 +42,7 @@ class LLC2160Model(BaseLLCModel):
                      'DRC','DRF','DXC','DXG','DYC','DYG',
                      'hFacC','hFacS','hFacW','PHrefC','PHrefF','RAC','RAS','RAW',
                      'RC','RF','rLowC','rLowS','rLowW','rSurfC',
-                     'rSurfS','rSurfW','XC','YC']
-    # unrecognized name: 'RhoRef'
+                     'RhoRef','rSurfS','rSurfW','XC','YC']
     # corner point problems: 'RAZ','XG','YG'
     mask_override = {'oceTAUX': 'c', 'oceTAUY': 'c'}
 
@@ -60,11 +59,11 @@ class LLC4320Model(BaseLLCModel):
     varnames = ['Eta', 'KPPhbl', 'oceFWflx', 'oceQnet', 'oceQsw', 'oceSflux',
                 'oceTAUX', 'oceTAUY', 'PhiBot', 'Salt', 'SIarea', 'SIheff',
                 'SIhsalt', 'SIhsnow', 'SIuice', 'SIvice', 'Theta', 'U', 'V', 'W']
-    grid_varnames = ['DRC','DRF','DXC','DXG','DYC','DYG',
+    grid_varnames = ['DRC','DRF','DXC','DXF','DXG','DYC','DYF','DYG',
                      'hFacC','hFacS','hFacW','PHrefC','PHrefF',
-                     'RAC','RAS','RAW','RC','RF','XC','YC']
-    # unrecognized name: 'RhoRef','DXV','DYU','DXF','DYF'
-    # corner point problems: 'RAZ','XG','YG'
+                     'RAC','RAS','RAW','RC','RF',
+                     'RhoRef','XC','YC']
+    # corner point problems: 'RAZ','XG','YG','DXV','DYU'
     mask_override = {'oceTAUX': 'c', 'oceTAUY': 'c'}
 
 

--- a/xmitgcm/llcreader/known_models.py
+++ b/xmitgcm/llcreader/known_models.py
@@ -41,7 +41,7 @@ class LLC2160Model(BaseLLCModel):
     grid_varnames = ['AngleCS','AngleSN','Depth',
                      'DRC','DRF','DXC','DXG','DYC','DYG',
                      'hFacC','hFacS','hFacW','PHrefC','PHrefF','RAC','RAS','RAW',
-                     'RC','RF','rhoRef','rLowC','rLowS','rLowW',
+                     'RC','RF','RhoRef','rLowC','rLowS','rLowW',
                      'rSurfC','rSurfS','rSurfW','XC','YC']
     # corner point problems: 'RAZ','XG','YG'
     mask_override = {'oceTAUX': 'c', 'oceTAUY': 'c'}

--- a/xmitgcm/llcreader/known_models.py
+++ b/xmitgcm/llcreader/known_models.py
@@ -38,6 +38,14 @@ class LLC2160Model(BaseLLCModel):
     varnames = ['Eta', 'KPPhbl', 'oceFWflx', 'oceQnet', 'oceQsw', 'oceSflux',
                 'oceTAUX', 'oceTAUY', 'PhiBot', 'Salt', 'SIarea', 'SIheff',
                 'SIhsalt', 'SIhsnow', 'SIuice', 'SIvice', 'Theta', 'U', 'V', 'W']
+    grid_varnames = ['AngleCS','AngleSN','Depth','DXC','DXG','DYC','DYG',
+                     'hFacC','hFacS','hFacW','RAC','RAS','RAW',
+                     'rLowC','rLowS','rLowW','rSurfC',
+                     'rSurfS','rSurfW','XC','YC']
+    # unrecognized name: 'RhoRef'   
+    # corner point problems: 'RAZ','XG','YG'
+    # k_p1 problems: 'DRC', 'PHrefF', 'RF'
+    # k problems: 'DRF', 'PHrefC', 'RC'
     mask_override = {'oceTAUX': 'c', 'oceTAUY': 'c'}
 
 
@@ -61,9 +69,10 @@ class ECCOPortalLLC2160Model(LLC2160Model):
     def __init__(self):
         fs = _make_http_filesystem()
         base_path = 'https://data.nas.nasa.gov/ecco/download_data.php?file=/eccodata/llc_2160/compressed'
+        grid_path = 'https://data.nas.nasa.gov/ecco/download_data.php?file=/eccodata/llc_2160/grid'
         mask_path = 'https://storage.googleapis.com/pangeo-ecco/llc/masks/llc_2160_masks.zarr/'
         store = stores.NestedStore(fs, base_path=base_path, mask_path=mask_path,
-                                   shrunk=True, join_char='/')
+                                   grid_path=grid_path,shrunk=True, join_char='/')
         super(ECCOPortalLLC2160Model, self).__init__(store)
 
 

--- a/xmitgcm/llcreader/known_models.py
+++ b/xmitgcm/llcreader/known_models.py
@@ -38,14 +38,13 @@ class LLC2160Model(BaseLLCModel):
     varnames = ['Eta', 'KPPhbl', 'oceFWflx', 'oceQnet', 'oceQsw', 'oceSflux',
                 'oceTAUX', 'oceTAUY', 'PhiBot', 'Salt', 'SIarea', 'SIheff',
                 'SIhsalt', 'SIhsnow', 'SIuice', 'SIvice', 'Theta', 'U', 'V', 'W']
-    grid_varnames = ['AngleCS','AngleSN','Depth','DXC','DXG','DYC','DYG',
-                     'hFacC','hFacS','hFacW','RAC','RAS','RAW',
-                     'rLowC','rLowS','rLowW','rSurfC',
+    grid_varnames = ['AngleCS','AngleSN','Depth',
+                     'DRC','DRF','DXC','DXG','DYC','DYG',
+                     'hFacC','hFacS','hFacW','PHrefC','PHrefF','RAC','RAS','RAW',
+                     'RC','RF','rLowC','rLowS','rLowW','rSurfC',
                      'rSurfS','rSurfW','XC','YC']
     # unrecognized name: 'RhoRef'   
     # corner point problems: 'RAZ','XG','YG'
-    # k_p1 problems: 'DRC', 'PHrefF', 'RF'
-    # k problems: 'DRF', 'PHrefC', 'RC'
     mask_override = {'oceTAUX': 'c', 'oceTAUY': 'c'}
 
 

--- a/xmitgcm/llcreader/known_models.py
+++ b/xmitgcm/llcreader/known_models.py
@@ -41,8 +41,8 @@ class LLC2160Model(BaseLLCModel):
     grid_varnames = ['AngleCS','AngleSN','Depth',
                      'DRC','DRF','DXC','DXG','DYC','DYG',
                      'hFacC','hFacS','hFacW','PHrefC','PHrefF','RAC','RAS','RAW',
-                     'RC','RF','rLowC','rLowS','rLowW','rSurfC',
-                     'RhoRef','rSurfS','rSurfW','XC','YC']
+                     'RC','RF','rhoRef','rLowC','rLowS','rLowW',
+                     'rSurfC','rSurfS','rSurfW','XC','YC']
     # corner point problems: 'RAZ','XG','YG'
     mask_override = {'oceTAUX': 'c', 'oceTAUY': 'c'}
 

--- a/xmitgcm/llcreader/known_models.py
+++ b/xmitgcm/llcreader/known_models.py
@@ -39,11 +39,14 @@ class LLC2160Model(BaseLLCModel):
                 'oceTAUX', 'oceTAUY', 'PhiBot', 'Salt', 'SIarea', 'SIheff',
                 'SIhsalt', 'SIhsnow', 'SIuice', 'SIvice', 'Theta', 'U', 'V', 'W']
     grid_varnames = ['AngleCS','AngleSN','Depth',
-                     'DRC','DRF','DXC','DXG','DYC','DYG',
-                     'hFacC','hFacS','hFacW','PHrefC','PHrefF','RAC','RAS','RAW',
+                     'DRC','DRF',
+                     'DXC','DXF','DXG',
+                     'DYC','DYF','DYG',
+                     'hFacC','hFacS','hFacW','PHrefC','PHrefF',
+                     'RAC','RAS','RAW',
                      'RC','RF','RhoRef','rLowC','rLowS','rLowW',
                      'rSurfC','rSurfS','rSurfW','XC','YC']
-    # corner point problems: 'RAZ','XG','YG'
+    # corner point problems: 'RAZ','XG','YG','DXV','DYU'
     mask_override = {'oceTAUX': 'c', 'oceTAUY': 'c'}
 
 
@@ -59,7 +62,10 @@ class LLC4320Model(BaseLLCModel):
     varnames = ['Eta', 'KPPhbl', 'oceFWflx', 'oceQnet', 'oceQsw', 'oceSflux',
                 'oceTAUX', 'oceTAUY', 'PhiBot', 'Salt', 'SIarea', 'SIheff',
                 'SIhsalt', 'SIhsnow', 'SIuice', 'SIvice', 'Theta', 'U', 'V', 'W']
-    grid_varnames = ['DRC','DRF','DXC','DXF','DXG','DYC','DYF','DYG',
+    grid_varnames = ['AngleCS','AngleSN','Depth',
+                     'DRC','DRF',
+                     'DXC','DXF','DXG',
+                     'DYC','DYF','DYG',
                      'hFacC','hFacS','hFacW','PHrefC','PHrefF',
                      'RAC','RAS','RAW','RC','RF',
                      'RhoRef','XC','YC']

--- a/xmitgcm/llcreader/known_models.py
+++ b/xmitgcm/llcreader/known_models.py
@@ -43,7 +43,7 @@ class LLC2160Model(BaseLLCModel):
                      'hFacC','hFacS','hFacW','PHrefC','PHrefF','RAC','RAS','RAW',
                      'RC','RF','rLowC','rLowS','rLowW','rSurfC',
                      'rSurfS','rSurfW','XC','YC']
-    # unrecognized name: 'RhoRef'   
+    # unrecognized name: 'RhoRef'
     # corner point problems: 'RAZ','XG','YG'
     mask_override = {'oceTAUX': 'c', 'oceTAUY': 'c'}
 
@@ -60,6 +60,11 @@ class LLC4320Model(BaseLLCModel):
     varnames = ['Eta', 'KPPhbl', 'oceFWflx', 'oceQnet', 'oceQsw', 'oceSflux',
                 'oceTAUX', 'oceTAUY', 'PhiBot', 'Salt', 'SIarea', 'SIheff',
                 'SIhsalt', 'SIhsnow', 'SIuice', 'SIvice', 'Theta', 'U', 'V', 'W']
+    grid_varnames = ['DRC','DRF','DXC','DXG','DYC','DYG',
+                     'hFacC','hFacS','hFacW','PHrefC','PHrefF',
+                     'RAC','RAS','RAW','RC','RF','XC','YC']
+    # unrecognized name: 'RhoRef','DXV','DYU','DXF','DYF'
+    # corner point problems: 'RAZ','XG','YG'
     mask_override = {'oceTAUX': 'c', 'oceTAUY': 'c'}
 
 
@@ -71,7 +76,7 @@ class ECCOPortalLLC2160Model(LLC2160Model):
         grid_path = 'https://data.nas.nasa.gov/ecco/download_data.php?file=/eccodata/llc_2160/grid'
         mask_path = 'https://storage.googleapis.com/pangeo-ecco/llc/masks/llc_2160_masks.zarr/'
         store = stores.NestedStore(fs, base_path=base_path, mask_path=mask_path,
-                                   grid_path=grid_path,shrunk=True, join_char='/')
+                                   grid_path=grid_path, shrunk=True, join_char='/')
         super(ECCOPortalLLC2160Model, self).__init__(store)
 
 
@@ -80,9 +85,10 @@ class ECCOPortalLLC4320Model(LLC4320Model):
     def __init__(self):
         fs = _make_http_filesystem()
         base_path = 'https://data.nas.nasa.gov/ecco/download_data.php?file=/eccodata/llc_4320/compressed'
+        grid_path = 'https://data.nas.nasa.gov/ecco/download_data.php?file=/eccodata/llc_4320/grid'
         mask_path = 'https://storage.googleapis.com/pangeo-ecco/llc/masks/llc_4320_masks.zarr/'
         store = stores.NestedStore(fs, base_path=base_path, mask_path=mask_path,
-                                   shrunk=True,  join_char='/')
+                                   grid_path=grid_path, shrunk=True, join_char='/')
         super(ECCOPortalLLC4320Model, self).__init__(store)
 
 

--- a/xmitgcm/llcreader/llcmodel.py
+++ b/xmitgcm/llcreader/llcmodel.py
@@ -796,8 +796,8 @@ class BaseLLCModel:
 
             variables[vname] = xr.Variable(dims, data[fname], attrs)
 
-        # handle vertical coordinate after the fact...
-        if read_grid:
+        # handle vertical coordinate after the fact
+        if read_grid and 'RF' in grid_varnames:
             ki = np.array([list(kp1_levels).index(x) for x in k_levels])
             for zv,sl in zip(['Zl','Zu'],[ki,ki+1]):
                 variables[zv] = xr.Variable(_VAR_METADATA[zv]['dims'],

--- a/xmitgcm/llcreader/llcmodel.py
+++ b/xmitgcm/llcreader/llcmodel.py
@@ -492,8 +492,8 @@ class BaseLLCModel:
         Final model iteration number (exclusive; follows python range conventions)
     iter_step : int
         Spacing between iterations
-    varnames : list
-        List of variable names contained in the dataset
+    varnames, grid_varnames : list
+        List of data variable and grid variable names contained in the dataset
     mask_override : dict
         Override inference of masking variable, e.g. ``{'oceTAUX': 'c'}``
     """

--- a/xmitgcm/llcreader/llcmodel.py
+++ b/xmitgcm/llcreader/llcmodel.py
@@ -109,7 +109,7 @@ _facet_strides = ((0,3), (3,6), (6,7), (7,10), (10,13))
 _facet_reshape = (False, False, False, True, True)
 _nfaces = 13
 _nfacets = 5
-_vgridvars = ['DRF','PHrefC','RC','DRF','PHrefF','RF']
+_vgridvars = ['DRC','DRF','PHrefC','PHrefF','RC','RF']
 
 def _uncompressed_facet_index(nfacet, nside):
     face_size = nside**2

--- a/xmitgcm/llcreader/llcmodel.py
+++ b/xmitgcm/llcreader/llcmodel.py
@@ -736,7 +736,8 @@ class BaseLLCModel:
         varnames = varnames or self.varnames
 
         # grid stuff
-        grid_vars_to_coords = read_grid and grid_vars_to_coords
+        read_grid = read_grid and len(self.grid_varnames)!=0
+        grid_vars_to_coords = grid_vars_to_coords and read_grid
         grid_varnames = self.grid_varnames if read_grid else []
 
         ds = self._make_coords_faces(iters)

--- a/xmitgcm/llcreader/llcmodel.py
+++ b/xmitgcm/llcreader/llcmodel.py
@@ -11,19 +11,11 @@ from .shrunk_index import all_index_data
 def _get_grid_metadata():
     # keep this separate from get_var_metadata
     # because grid stuff is weird
-    from ..variables import (horizontal_coordinates_llc,
-            vertical_coordinates, vertical_grid_variables,
-            horizontal_grid_variables, volume_grid_variables,
-            mask_variables, extra_grid_variables)
+    from ..mds_store import _get_all_grid_variables
+    from ..variables import extra_grid_variables, vertical_coordinates
 
     # get grid info
-    # keys are variable names
-    grid_vars = horizontal_coordinates_llc.copy()
-    grid_vars.update(horizontal_grid_variables)
-    grid_vars.update(vertical_coordinates)
-    grid_vars.update(vertical_grid_variables)
-    grid_vars.update(volume_grid_variables)
-    grid_vars.update(mask_variables)
+    grid_vars = _get_all_grid_variables('llc')
     grid_vars.update(extra_grid_variables)
 
     # make dictionary with keys as filenames

--- a/xmitgcm/llcreader/llcmodel.py
+++ b/xmitgcm/llcreader/llcmodel.py
@@ -18,9 +18,9 @@ def _get_grid_metadata():
 
     # get grid info
     # keys are variable names
-    grid_vars = horizontal_coordinates_llc 
-    grid_vars.update(vertical_coordinates)
+    grid_vars = horizontal_coordinates_llc.copy()
     grid_vars.update(horizontal_grid_variables)
+    grid_vars.update(vertical_coordinates)
     grid_vars.update(vertical_grid_variables)
     grid_vars.update(volume_grid_variables)
     grid_vars.update(mask_variables)
@@ -54,7 +54,7 @@ def _get_var_metadata():
 
     diag_file = StringIO(diagnostics)
     available_diags = parse_available_diagnostics(diag_file)
-    var_metadata = state_variables
+    var_metadata = state_variables.copy()
     var_metadata.update(package_state_variables)
     var_metadata.update(available_diags)
 

--- a/xmitgcm/llcreader/llcmodel.py
+++ b/xmitgcm/llcreader/llcmodel.py
@@ -373,14 +373,18 @@ def _get_facet_chunk(store, varname, iternum, nfacet, klevels, nx, nz, dtype,
 
     file = fs.open(path)
 
-    # insert singleton axis for time and k level
-    facet_shape = (1, 1,) + _facet_shape(nfacet, nx)
+    # insert singleton axis for time (if not grid var) and k level
+    facet_shape = (1,) + _facet_shape(nfacet, nx)
+    facet_shape = (1,) + facet_shape if iternum is not None else facet_shape
 
     level_data = []
 
     # the store tells us whether we need a mask or not
     point = _get_variable_point(varname, mask_override)
-    if store.shrunk:
+
+    # it seems grid variables are not shrunk even though
+    # data variables are...
+    if store.shrunk and iternum is not None:
         index = all_index_data[nx][point]
         zgroup = store.open_mask_group()
         mask = zgroup['mask_' + point].astype('bool')

--- a/xmitgcm/llcreader/llcmodel.py
+++ b/xmitgcm/llcreader/llcmodel.py
@@ -126,7 +126,7 @@ _facet_strides = ((0,3), (3,6), (6,7), (7,10), (10,13))
 _facet_reshape = (False, False, False, True, True)
 _nfaces = 13
 _nfacets = 5
-_vgrid_prefixes = ['DRC','DRF','PHrefC','PHrefF','RC','RF']
+_vgrid_prefixes = ['DRC','DRF','PHrefC','PHrefF','RC','RF','RhoRef']
 _vgrid_p1_prefixes = ['DRC','PHrefF','RF']
 
 def _uncompressed_facet_index(nfacet, nside):

--- a/xmitgcm/llcreader/stores.py
+++ b/xmitgcm/llcreader/stores.py
@@ -43,9 +43,14 @@ class BaseStore:
             return self.grid_path
 
     def _fname(self, varname, iternum):
-        fname = varname + '.%010d.data' % iternum if iternum is not None else varname
-        if self.shrunk:
-            fname += '.shrunk'
+
+        if iternum is not None:
+            fname = varname + '.%010d.data' % iternum
+            if self.shrunk:
+                fname += '.shrunk'
+        else:
+            fname = varname + '.data'
+
         return fname
 
     def _join(self, *args):
@@ -109,4 +114,7 @@ class NestedStore(BaseStore):
     iteration number."""
 
     def _directory(self, varname, iternum):
-        return self._join(self.base_path, '%010d' % iternum)
+        if iternum is not None:
+            return self._join(self.base_path, '%010d' % iternum)
+        else:
+            return self.grid_path

--- a/xmitgcm/llcreader/stores.py
+++ b/xmitgcm/llcreader/stores.py
@@ -13,17 +13,21 @@ class BaseStore:
         Where to find the data within the filesystem
     shrunk : bool, optional
         Whether the data files have been tagged with `.shrunk`
-    mask_fs : fsspec.AbstractFileSystem, optional
-        Where to find the mask datasets to decode the compression
-    mask_path : str, optional
-        Path the the mask datasets on the ``mask_fs`` filesystem
+    mask_fs, grid_fs : fsspec.AbstractFileSystem, optional
+        Where to find the mask or grid datasets to decode the compression
+    mask_path, grid_path : str, optional
+        Path to the mask or grid datasets on the ``mask_fs`` or ``grid_fs`` filesystem
+    shrunk_grid : bool, optional
+        Whether the grid files have been tagged with `.shrunk`
+        not always the same as for data variables
     join_char : str or None
         Character to use to join paths. Falls back on os.path.join if None.
     """
 
     def __init__(self, fs, base_path='/', shrunk=False,
                  mask_fs=None, mask_path=None, 
-                 grid_fs=None, grid_path=None, join_char=None):
+                 grid_fs=None, grid_path=None,
+                 shrunk_grid=False, join_char=None):
         self.base_path = base_path
         self.fs = fs
         self.shrunk = shrunk
@@ -31,6 +35,7 @@ class BaseStore:
         self.mask_path = mask_path
         self.grid_fs = grid_fs or self.fs
         self.grid_path = grid_path
+        self.shrunk_grid = shrunk_grid
         self.join_char = join_char
         if shrunk and (mask_path is None):
             raise ValueError("`mask_path` can't be None if `shrunk` is True")
@@ -50,6 +55,8 @@ class BaseStore:
                 fname += '.shrunk'
         else:
             fname = varname + '.data'
+            if self.shrunk_grid:
+                fname = varname + '.shrunk'
 
         return fname
 

--- a/xmitgcm/llcreader/stores.py
+++ b/xmitgcm/llcreader/stores.py
@@ -22,22 +22,28 @@ class BaseStore:
     """
 
     def __init__(self, fs, base_path='/', shrunk=False,
-                 mask_fs=None, mask_path=None, join_char=None):
+                 mask_fs=None, mask_path=None, 
+                 grid_fs=None, grid_path=None, join_char=None):
         self.base_path = base_path
         self.fs = fs
         self.shrunk = shrunk
         self.mask_fs = mask_fs or self.fs
         self.mask_path = mask_path
+        self.grid_fs = grid_fs or self.fs
+        self.grid_path = grid_path
         self.join_char = join_char
         if shrunk and (mask_path is None):
             raise ValueError("`mask_path` can't be None if `shrunk` is True")
 
 
     def _directory(self, varname, iternum):
-        return self.base_path
+        if iternum is not None:
+            return self.base_path
+        else:
+            return self.grid_path
 
     def _fname(self, varname, iternum):
-        fname = varname + '.%010d.data' % iternum
+        fname = varname + '.%010d.data' % iternum if iternum is not None else varname
         if self.shrunk:
             fname += '.shrunk'
         return fname

--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -763,7 +763,7 @@ def _guess_layers(data_dir):
     return all_layers
 
 
-def _get_all_grid_variables(geometry, grid_dir, layers={}):
+def _get_all_grid_variables(geometry, grid_dir=None, layers={}):
     """"Put all the relevant grid metadata into one big dictionary."""
     possible_hcoords = {'cartesian': horizontal_coordinates_cartesian,
                         'llc': horizontal_coordinates_llc,
@@ -772,7 +772,7 @@ def _get_all_grid_variables(geometry, grid_dir, layers={}):
     hcoords = possible_hcoords[geometry]
 
     # look for extra variables, if they exist in grid_dir
-    extravars = _get_extra_grid_variables(grid_dir)
+    extravars = _get_extra_grid_variables(grid_dir) if grid_dir is not None else {}
 
     allvars = [hcoords, vertical_coordinates, horizontal_grid_variables,
                vertical_grid_variables, volume_grid_variables, mask_variables,

--- a/xmitgcm/test/test_llcreader.py
+++ b/xmitgcm/test/test_llcreader.py
@@ -11,11 +11,11 @@ EXPECTED_VARS = ['Eta', 'KPPhbl', 'oceFWflx', 'oceQnet', 'oceQsw', 'oceSflux',
 EXPECTED_COORDS = {2160: ['CS','SN','Depth',
                           'drC','drF','dxC','dxG','dyC','dyG',
                           'hFacC','hFacS','hFacW','PHrefC','PHrefF','rA','rAs','rAw',
-                          'Z','Zp1','rLowC','rLowS','rLowW','rSurfC',
+                          'Z','Zl','rLowC','rLowS','rLowW','rSurfC',
                           'rSurfS','rSurfW','XC','YC'],
                    4320: ['drC','drF','dxC','dxG','dyC','dyG',
                           'hFacC','hFacS','hFacW','PHrefC','PHrefF',
-                          'rA','rAs','rAw','Z','Zp1','XC','YC']}
+                          'rA','rAs','rAw','Z','Zl','XC','YC']}
 
 ########### Generic llcreader tests on local data ##############################
 

--- a/xmitgcm/test/test_llcreader.py
+++ b/xmitgcm/test/test_llcreader.py
@@ -49,18 +49,22 @@ def test_llc90_local_latlon(local_llc90_store, llc90_kwargs):
                               'j_g': 270, 'j': 270}
 
 @pytest.mark.parametrize('rettype', ['faces', 'latlon'])
-@pytest.mark.parametrize('k_levels', [None, [0, 2, 7, 9, 10, 20]])
+@pytest.mark.parametrize('k_levels,kp1_levels', 
+        [None, [0, 2, 7, 9, 10, 20],
+        [None, [0,1,2,3,7,8,9,10,11,20,21])
 @pytest.mark.parametrize('k_chunksize', [1, 2])
 def test_llc90_local_faces_load(local_llc90_store, llc90_kwargs, rettype, k_levels,
-                                k_chunksize):
+                                kp1_levels, k_chunksize):
     store = local_llc90_store
     model = llcreader.LLC90Model(store)
     ds = model.get_dataset(k_levels=k_levels, k_chunksize=k_chunksize,
                            type=rettype, **llc90_kwargs)
     if k_levels is None:
         assert list(ds.k.values) == list(range(50))
+        assert list(ds.k_p1.values) == list(range(50))
     else:
         assert list(ds.k.values) == k_levels
+        assert list(ds.k_p1.values) == k_levels
     assert all([cs==k_chunksize for cs in ds['T'].data.chunks[1]])
 
     ds.load()

--- a/xmitgcm/test/test_llcreader.py
+++ b/xmitgcm/test/test_llcreader.py
@@ -114,3 +114,9 @@ def test_ecco_portal_latlon(ecco_portal_model):
                              'j': 3*nx, 'face': 13}
     assert set(EXPECTED_VARS) == set(ds_ll.data_vars)
     assert set(EXPECTED_COORDS[nx]).issubset(set(ds_ll.coords))
+
+    # make sure vertical coordinates are in one single chunk
+    for fld in ds_faces[['Z','Zl','Zu','Zp1']].coords:
+        if isinstance(ds_faces[fld].data,dsa):
+            assert len(ds_faces[fld].data.chunks)==1
+            assert (len(ds_faces[fld]),)==ds_faces[fld].data.chunks[0]

--- a/xmitgcm/test/test_llcreader.py
+++ b/xmitgcm/test/test_llcreader.py
@@ -62,10 +62,10 @@ def test_llc90_local_faces_load(local_llc90_store, llc90_kwargs, rettype, k_leve
                            type=rettype, **llc90_kwargs)
     if k_levels is None:
         assert list(ds.k.values) == list(range(50))
-        assert list(ds.k_p1.values) == list(range(50))
+        assert list(ds.k_p1.values) == list(range(51))
     else:
         assert list(ds.k.values) == k_levels
-        assert list(ds.k_p1.values) == k_levels
+        assert list(ds.k_p1.values) == kp1_levels
     assert all([cs==k_chunksize for cs in ds['T'].data.chunks[1]])
 
     ds.load()

--- a/xmitgcm/test/test_llcreader.py
+++ b/xmitgcm/test/test_llcreader.py
@@ -10,11 +10,12 @@ EXPECTED_VARS = ['Eta', 'KPPhbl', 'oceFWflx', 'oceQnet', 'oceQsw', 'oceSflux',
             'SIhsalt', 'SIhsnow', 'SIuice', 'SIvice', 'Theta', 'U', 'V', 'W']
 
 EXPECTED_COORDS = {2160: ['CS','SN','Depth',
-                          'drC','drF','dxC','dxG','dyC','dyG',
+                          'drC','drF','dxC','dxF','dxG','dyC','dyF','dyG',
                           'hFacC','hFacS','hFacW','PHrefC','PHrefF','rA','rAs','rAw',
                           'Z','Zp1','Zl','Zu','rhoRef','rLowC','rLowS','rLowW',
                           'rSurfC','rSurfS','rSurfW','XC','YC'],
-                   4320: ['drC','drF','dxC','dxF','dxG','dyC','dyF','dyG',
+                   4320: ['CS','SN','Depth',
+                          'drC','drF','dxC','dxF','dxG','dyC','dyF','dyG',
                           'hFacC','hFacS','hFacW','PHrefC','PHrefF',
                           'rA','rAs','rAw','rhoRef','Z','Zp1','Zl','Zu','XC','YC']}
 

--- a/xmitgcm/test/test_llcreader.py
+++ b/xmitgcm/test/test_llcreader.py
@@ -11,11 +11,11 @@ EXPECTED_VARS = ['Eta', 'KPPhbl', 'oceFWflx', 'oceQnet', 'oceQsw', 'oceSflux',
 EXPECTED_COORDS = {2160: ['CS','SN','Depth',
                           'drC','drF','dxC','dxG','dyC','dyG',
                           'hFacC','hFacS','hFacW','PHrefC','PHrefF','rA','rAs','rAw',
-                          'Z','Zl','rLowC','rLowS','rLowW','rSurfC',
+                          'Z','Zp1','Zl','Zu','rLowC','rLowS','rLowW','rSurfC',
                           'rSurfS','rSurfW','XC','YC'],
                    4320: ['drC','drF','dxC','dxG','dyC','dyG',
                           'hFacC','hFacS','hFacW','PHrefC','PHrefF',
-                          'rA','rAs','rAw','Z','Zl','XC','YC']}
+                          'rA','rAs','rAw','Z','Zp1','Zl','Zu','XC','YC']}
 
 ########### Generic llcreader tests on local data ##############################
 

--- a/xmitgcm/test/test_llcreader.py
+++ b/xmitgcm/test/test_llcreader.py
@@ -37,14 +37,14 @@ def test_llc90_local_faces(local_llc90_store, llc90_kwargs):
     ds_faces = model.get_dataset(**llc90_kwargs)
     assert set(llc90_kwargs['varnames']) == set(ds_faces.data_vars)
     assert ds_faces.dims == {'face': 13, 'i': 90, 'i_g': 90, 'j': 90, 'j_g': 90,
-                             'k': 50, 'k_u': 50, 'k_l': 50, 'k_p1': 50, 'time': 2}
+                             'k': 50, 'k_u': 50, 'k_l': 50, 'k_p1': 51, 'time': 2}
 
 def test_llc90_local_latlon(local_llc90_store, llc90_kwargs):
     store = local_llc90_store
     model = llcreader.LLC90Model(store)
     ds_latlon = model.get_dataset(type='latlon', **llc90_kwargs)
     assert set(llc90_kwargs['varnames']) == set(ds_latlon.data_vars)
-    assert ds_latlon.dims == {'i': 360, 'time': 2, 'k_p1': 50, 'face': 13,
+    assert ds_latlon.dims == {'i': 360, 'time': 2, 'k_p1': 51, 'face': 13,
                               'i_g': 360, 'k_u': 50, 'k': 50, 'k_l': 50,
                               'j_g': 270, 'j': 270}
 
@@ -81,7 +81,7 @@ def test_ecco_portal_faces(ecco_portal_model):
     nx = ecco_portal_model.nx
     assert ds_faces.dims == {'face': 13, 'i': nx, 'i_g': nx, 'j': nx,
                               'j_g': nx, 'k': 90, 'k_u': 90, 'k_l': 90,
-                              'k_p1': 90, 'time': 3}
+                              'k_p1': 91, 'time': 3}
     assert set(EXPECTED_VARS) == set(ds_faces.data_vars)
     assert set(EXPECTED_COORDS[nx]).issubset(set(ds_faces.coords))
 
@@ -98,7 +98,7 @@ def test_ecco_portal_latlon(ecco_portal_model):
     ds_ll = ecco_portal_model.get_dataset(iter_stop=iter_stop, type='latlon')
     nx = ecco_portal_model.nx
     assert ds_ll.dims == {'i': 4*nx, 'k_u': 90, 'k_l': 90, 'time': 3,
-                             'k': 90, 'j_g': 3*nx, 'i_g': 4*nx, 'k_p1': 90,
+                             'k': 90, 'j_g': 3*nx, 'i_g': 4*nx, 'k_p1': 91,
                              'j': 3*nx, 'face': 13}
     assert set(EXPECTED_VARS) == set(ds_ll.data_vars)
     assert set(EXPECTED_COORDS[nx]).issubset(set(ds_ll.coords))

--- a/xmitgcm/test/test_llcreader.py
+++ b/xmitgcm/test/test_llcreader.py
@@ -69,12 +69,6 @@ def test_llc90_local_faces_load(local_llc90_store, llc90_kwargs, rettype, k_leve
         assert list(ds.k_p1.values) == kp1_levels
     assert all([cs==k_chunksize for cs in ds['T'].data.chunks[1]])
 
-    # make sure vertical coordinates are in one single chunk
-    for fld in ds['Z','Zl','Zu','Zp1'].coords:
-        if isinstance(ds[fld].data,dsa):
-            assert len(ds[fld].data.chunks)==1
-            assert (len(ds[fld]),)==ds[fld].data.chunks[0]
-
     ds.load()
 
 ########### ECCO Portal Tests ##################################################
@@ -96,6 +90,12 @@ def test_ecco_portal_faces(ecco_portal_model):
                               'k_p1': 91, 'time': 3}
     assert set(EXPECTED_VARS) == set(ds_faces.data_vars)
     assert set(EXPECTED_COORDS[nx]).issubset(set(ds_faces.coords))
+
+    # make sure vertical coordinates are in one single chunk
+    for fld in ds_faces[['Z','Zl','Zu','Zp1']].coords:
+        if isinstance(ds_faces[fld].data,dsa):
+            assert len(ds_faces[fld].data.chunks)==1
+            assert (len(ds_faces[fld]),)==ds_faces[fld].data.chunks[0]
 
 def test_ecco_portal_load(ecco_portal_model):
     # an expensive test because it actually loads data

--- a/xmitgcm/test/test_llcreader.py
+++ b/xmitgcm/test/test_llcreader.py
@@ -8,14 +8,14 @@ EXPECTED_VARS = ['Eta', 'KPPhbl', 'oceFWflx', 'oceQnet', 'oceQsw', 'oceSflux',
             'oceTAUX', 'oceTAUY', 'PhiBot', 'Salt', 'SIarea', 'SIheff',
             'SIhsalt', 'SIhsnow', 'SIuice', 'SIvice', 'Theta', 'U', 'V', 'W']
 
-EXPECTED_COORDS = {2160: ['AngleCS','AngleSN','Depth',
-                          'DRC','DRF','DXC','DXG','DYC','DYG',
-                          'hFacC','hFacS','hFacW','PHrefC','PHrefF','RAC','RAS','RAW',
-                          'RC','RF','rLowC','rLowS','rLowW','rSurfC',
+EXPECTED_COORDS = {2160: ['CS','SN','Depth',
+                          'drC','drF','dxC','dxG','dyC','dyG',
+                          'hFacC','hFacS','hFacW','PHrefC','PHrefF','rA','rAs','rAw',
+                          'Z','Zp1','rLowC','rLowS','rLowW','rSurfC',
                           'rSurfS','rSurfW','XC','YC'],
-                   4320: ['DRC','DRF','DXC','DXG','DYC','DYG',
+                   4320: ['drC','drF','dxC','dxG','dyC','dyG',
                           'hFacC','hFacS','hFacW','PHrefC','PHrefF',
-                          'RAC','RAS','RAW','RC','RF','XC','YC']}
+                          'rA','rAs','rAw','Z','Zp1','XC','YC']}
 
 ########### Generic llcreader tests on local data ##############################
 

--- a/xmitgcm/test/test_llcreader.py
+++ b/xmitgcm/test/test_llcreader.py
@@ -49,9 +49,10 @@ def test_llc90_local_latlon(local_llc90_store, llc90_kwargs):
                               'j_g': 270, 'j': 270}
 
 @pytest.mark.parametrize('rettype', ['faces', 'latlon'])
-@pytest.mark.parametrize('k_levels,kp1_levels', 
-        [None, [0, 2, 7, 9, 10, 20],
-        [None, [0,1,2,3,7,8,9,10,11,20,21])
+@pytest.mark.parametrize('k_levels, kp1_levels', 
+        [(None,None),
+         ([0, 2, 7, 9, 10, 20],
+          [0,1,2,3,7,8,9,10,11,20,21])])
 @pytest.mark.parametrize('k_chunksize', [1, 2])
 def test_llc90_local_faces_load(local_llc90_store, llc90_kwargs, rettype, k_levels,
                                 kp1_levels, k_chunksize):

--- a/xmitgcm/test/test_llcreader.py
+++ b/xmitgcm/test/test_llcreader.py
@@ -8,6 +8,15 @@ EXPECTED_VARS = ['Eta', 'KPPhbl', 'oceFWflx', 'oceQnet', 'oceQsw', 'oceSflux',
             'oceTAUX', 'oceTAUY', 'PhiBot', 'Salt', 'SIarea', 'SIheff',
             'SIhsalt', 'SIhsnow', 'SIuice', 'SIvice', 'Theta', 'U', 'V', 'W']
 
+EXPECTED_COORDS = {2160: ['AngleCS','AngleSN','Depth',
+                          'DRC','DRF','DXC','DXG','DYC','DYG',
+                          'hFacC','hFacS','hFacW','PHrefC','PHrefF','RAC','RAS','RAW',
+                          'RC','RF','rLowC','rLowS','rLowW','rSurfC',
+                          'rSurfS','rSurfW','XC','YC'],
+                   4320: ['DRC','DRF','DXC','DXG','DYC','DYG',
+                          'hFacC','hFacS','hFacW','PHrefC','PHrefF',
+                          'RAC','RAS','RAW','RC','RF','XC','YC']}
+
 ########### Generic llcreader tests on local data ##############################
 
 @pytest.fixture(scope='module')
@@ -74,6 +83,7 @@ def test_ecco_portal_faces(ecco_portal_model):
                               'j_g': nx, 'k': 90, 'k_u': 90, 'k_l': 90,
                               'k_p1': 90, 'time': 3}
     assert set(EXPECTED_VARS) == set(ds_faces.data_vars)
+    assert set(EXPECTED_COORDS[nx]).issubset(set(ds_faces.coords))
 
 def test_ecco_portal_load(ecco_portal_model):
     # an expensive test because it actually loads data
@@ -91,3 +101,4 @@ def test_ecco_portal_latlon(ecco_portal_model):
                              'k': 90, 'j_g': 3*nx, 'i_g': 4*nx, 'k_p1': 90,
                              'j': 3*nx, 'face': 13}
     assert set(EXPECTED_VARS) == set(ds_ll.data_vars)
+    assert set(EXPECTED_COORDS[nx]).issubset(set(ds_ll.coords))

--- a/xmitgcm/test/test_llcreader.py
+++ b/xmitgcm/test/test_llcreader.py
@@ -1,4 +1,5 @@
 import pytest
+from dask.array.core import Array as dsa
 
 llcreader = pytest.importorskip("xmitgcm.llcreader")
 
@@ -67,6 +68,12 @@ def test_llc90_local_faces_load(local_llc90_store, llc90_kwargs, rettype, k_leve
         assert list(ds.k.values) == k_levels
         assert list(ds.k_p1.values) == kp1_levels
     assert all([cs==k_chunksize for cs in ds['T'].data.chunks[1]])
+
+    # make sure vertical coordinates are in one single chunk
+    for fld in ds['Z','Zl','Zu','Zp1'].coords:
+        if isinstance(ds[fld].data,dsa):
+            assert len(ds[fld].data.chunks)==1
+            assert (len(ds[fld]),)==ds[fld].data.chunks[0]
 
     ds.load()
 

--- a/xmitgcm/test/test_llcreader.py
+++ b/xmitgcm/test/test_llcreader.py
@@ -11,11 +11,11 @@ EXPECTED_VARS = ['Eta', 'KPPhbl', 'oceFWflx', 'oceQnet', 'oceQsw', 'oceSflux',
 EXPECTED_COORDS = {2160: ['CS','SN','Depth',
                           'drC','drF','dxC','dxG','dyC','dyG',
                           'hFacC','hFacS','hFacW','PHrefC','PHrefF','rA','rAs','rAw',
-                          'Z','Zp1','Zl','Zu','rLowC','rLowS','rLowW','rSurfC',
-                          'rSurfS','rSurfW','XC','YC'],
-                   4320: ['drC','drF','dxC','dxG','dyC','dyG',
+                          'Z','Zp1','Zl','Zu','rhoRef','rLowC','rLowS','rLowW',
+                          'rSurfC','rSurfS','rSurfW','XC','YC'],
+                   4320: ['drC','drF','dxC','dxF','dxG','dyC','dyF','dyG',
                           'hFacC','hFacS','hFacW','PHrefC','PHrefF',
-                          'rA','rAs','rAw','Z','Zp1','Zl','Zu','XC','YC']}
+                          'rA','rAs','rAw','rhoRef','Z','Zp1','Zl','Zu','XC','YC']}
 
 ########### Generic llcreader tests on local data ##############################
 

--- a/xmitgcm/test/test_llcreader.py
+++ b/xmitgcm/test/test_llcreader.py
@@ -116,7 +116,7 @@ def test_ecco_portal_latlon(ecco_portal_model):
     assert set(EXPECTED_COORDS[nx]).issubset(set(ds_ll.coords))
 
     # make sure vertical coordinates are in one single chunk
-    for fld in ds_faces[['Z','Zl','Zu','Zp1']].coords:
-        if isinstance(ds_faces[fld].data,dsa):
-            assert len(ds_faces[fld].data.chunks)==1
-            assert (len(ds_faces[fld]),)==ds_faces[fld].data.chunks[0]
+    for fld in ds_ll[['Z','Zl','Zu','Zp1']].coords:
+        if isinstance(ds_ll[fld].data,dsa):
+            assert len(ds_ll[fld].data.chunks)==1
+            assert (len(ds_ll[fld]),)==ds_ll[fld].data.chunks[0]

--- a/xmitgcm/variables.py
+++ b/xmitgcm/variables.py
@@ -651,14 +651,14 @@ extra_grid_variables = OrderedDict(
     maskCtrlS=dict(dims=['k', 'j_g', 'i'], attrs=dict(
         standard_name="ctrl_vector_3d_mask_at_v_location",
         long_name='CTRL 3D mask where ctrl vector is active at v location',
-        units=''))
+        units='')),
     # Reference density profile
     rhoRef=dict(dims=['k'],attrs=dict(
         standard_name="reference_density_profile",
         long_name="1D, vertical reference density profile",
         coordinate="Z",
         units='kg m-3'),
-        filename='RhoRef')
+        filename='RhoRef'),
     # Additional grid metrics
     dxF=dict(dims=['j','i'],attrs=dict(
         standard_name="cell_x_size_at_t_location",

--- a/xmitgcm/variables.py
+++ b/xmitgcm/variables.py
@@ -652,6 +652,30 @@ extra_grid_variables = OrderedDict(
         standard_name="ctrl_vector_3d_mask_at_v_location",
         long_name='CTRL 3D mask where ctrl vector is active at v location',
         units=''))
+    # Reference density profile
+    rhoRef=dict(dims=['k'],attrs=dict(
+        standard_name="reference_density_profile",
+        long_name="1D, vertical reference density profile",
+        coordinate="Z",
+        units='kg m-3'),
+        filename='RhoRef')
+    # Additional grid metrics
+    dxF=dict(dims=['j','i'],attrs=dict(
+        standard_name="cell_x_size_at_t_location",
+        long_name="cell x size", units="m", coordinate="YC XC"),
+        filename='DXF'),
+    dyF=dict(dims=['j','i'],attrs=dict(
+        standard_name="cell_y_size_at_t_location",
+        long_name="cell y size", units="m", coordinate="YC XC"),
+        filename='DYF'),
+    dxV=dict(dims=['j_g','i_g'],attrs=dict(
+        standard_name="cell_x_size_at_f_location",
+        long_name="cell x size", units="m", coordinate="YG XG"),
+        filename='DXV'),
+    dyU=dict(dims=['j_g','i_g'],attrs=dict(
+        standard_name="cell_y_size_at_f_location",
+        long_name="cell y size", units="m", coordinate="YG XG"),
+        filename='DYU')
     # Printed from write_grid when sigma coordinates are used
     # AHybSigmF, BHybSigF, ...
     # Unclear where on the grid these variables exist,

--- a/xmitgcm/variables.py
+++ b/xmitgcm/variables.py
@@ -187,7 +187,7 @@ horizontal_grid_variables = OrderedDict(
     rAs=dict(dims=["j_g", "i"], attrs=dict(
         standard_name="cell_area_at_v_location",
         long_name="cell area", units="m2", coordinates="YG XC"),
-        filename='RAZ'),
+        filename='RAS'),
 )
 
 vertical_grid_variables = OrderedDict(


### PR DESCRIPTION
This PR is designed to give llcreader access to grid information on the ECCO portal (or elsewhere), to hopefully to close #161, close #166, and close #158 (possibly more).

Right now it gets the full grid for LLC 2160 and gets the available grid info on the ECCO portal for LLC 4320, which is some but not all. I was not able access the grid info mentioned by @rabernat in #161, which was [here](https://pangeo-data.github.io/pangeo-datastore/master/ocean/llc4320.html#llc4320-grid)

**vertical grid variables and coordinates**
this got a little tricky since everything is designed to deal with faceted data. I wrote some functions to read these in differently. I adapted the same infrastructure to the 1D variables, even though they could probably be dealt with eagerly (see `_get_1d_chunk` and `_dask_array_vgrid` in llcmodel.py).

**`k_p1` index**
I changed this implementation as follows. Currently, the code grabs `k_levels` for `k_p1` where `k_levels` is the cell centered index. Even if the user does not select levels, this still results in `len(k)==len(k_p1)`, which is technically not right, unless I'm missing something... It gets tricky though when the user selects individual, nonconsecutive levels. I wrote this PR so that, if the user selects cell centered `k_levels=[0,10,11]` then the output dataset has `k_p1=[0,1,10,11,12]` - so that `k_p1` has the upper and lower indices for each vertical grid cell. I found this easier to do in order to correctly assign `Zu`,`Zl`, and `Zp1`. This implementation "seems right", but I'm interested if anyone has an idea for how to handle it more elegantly or if it's unnecessary/confusing. It also felt like a somewhat hacky solution, so again, feedback welcome. (see `_get_kp1_levels` in llcmodel.py). With this new implementation I had to change the expected size of `k_p1` to be 51 and 91 for llc90 and llc2160/llc4320.

**tests**
I just appended checks for this stuff in current tests rather than adding new ones. Tests for the `k_p1` levels is in `test_llc90_local_faces_load` and 2160/4320 grids checked for in `test_ecco_portal_faces/latlon`. Perhaps could add more, testing the added `read_grid` and `grid_vars_to_coords` options added to `get_dataset`.

Some of the implementation started to feel a little hacky, and I'm open to anyone's suggestion on making it cleaner. Let me know what you think! 
