### PR TITLE
fix py36 xarray master build

### DIFF
--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -235,8 +235,11 @@ def open_mdsdataset(data_dir, grid_dir=None,
                 # apply chunking
                 if sys.version_info[0] < 3:
                     ds = xr.auto_combine(datasets)
-                else:
+                elif xr.__version__ < '0.15.2':
                     ds = xr.combine_by_coords(datasets)
+                else:
+                    ds = xr.combine_by_coords(datasets,combine_attrs='drop')
+
                 if swap_dims:
                     ds = _swap_dimensions(ds, geometry)
                 if grid_vars_to_coords:


### PR DESCRIPTION
This (seems to) fix the current bug with the python 3.6, xarray master build. It seems that the newest version of `xarray.combine_by_coords` added the option `combine_attrs`, allowing the user to specify how to handle attributes while combining multiple datasets. The default is `no_conflicts`, which in this case causes a problem with the `history` attribute since each dataset corresponds to an iteration (or None for the grid), each of which is different and shows up in this attribute as "created by calling open_mdsdataset(.....)"

It seems that the old default was to simply drop attributes, so that's what I'm setting the option to for a first pass. We could also just drop the attributes before calling `xr.combine_by_coords`, and remove the need for testing.