### PR TITLE
Including data from the Arctic cap facet to transformed data when using llcrearrange

### DIFF
--- a/xmitgcm/llcreader/llcmodel.py
+++ b/xmitgcm/llcreader/llcmodel.py
@@ -197,10 +197,6 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
         arct_facet: New arctic cap data into a new facet, associated with
                     varName
     '''
-    if 'tile' in ds.dims:
-        face = 'tile'
-    else:
-        face = 'face'
     arc_cap = 6
     ARCT = []
     afaces = [2, 5, 7, 10]  # order of faces with which artic cap connects
@@ -208,7 +204,7 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
         if k == 2:
             fac = 1
             _varName = varName  # copy, b/c varName may change
-            DIMS = [dim for dim in ds[_varName].dims if dim != face]
+            DIMS = [dim for dim in ds[_varName].dims if dim != 'face']
             dims = Dims(DIMS[::-1])
             dtr = list(dims)[::-1]
             dtr[-1], dtr[-2] = dtr[-2], dtr[-1]
@@ -219,7 +215,7 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
             y0, yf = 0, int(len(ds[dims.X]))
             xslice = slice(x0, xf)
             yslice = slice(y0, yf)
-            da_arg = {face: arc_cap, dims.X: xslice, dims.Y: yslice}
+            da_arg = {'face': arc_cap, dims.X: xslice, dims.Y: yslice}
             sort_arg = {'variables': dims.Y, 'ascending': False}
             mask_arg = {dims.X: xslice, dims.Y: yslice}
             if len(dims.X) + len(dims.Y) == 4:  # vector field or metric
@@ -227,14 +223,14 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
                     fac = - 1
                 if 'mate' in list(ds[_varName].attrs):
                     _varName = ds[_varName].attrs['mate']
-                _DIMS = [dim for dim in ds[_varName].dims if dim != face]
+                _DIMS = [dim for dim in ds[_varName].dims if dim != 'face']
                 dims = Dims(_DIMS[::-1])
                 dtr = list(dims)[::-1]
                 dtr[-1], dtr[-2] = dtr[-2], dtr[-1]
                 mask2 = xr.ones_like(ds[_varName].isel(face=arc_cap))
                 mask2 = mask2.where(np.logical_and(ds[dims.X] < ds[dims.Y],
                                     ds[dims.X] < len(ds[dims.Y]) - ds[dims.Y]))
-                da_arg = {face: arc_cap, dims.X: xslice, dims.Y: yslice}
+                da_arg = {'face': arc_cap, dims.X: xslice, dims.Y: yslice}
                 sort_arg = {'variables': dims.Y, 'ascending': False}
                 mask_arg = {dims.X: xslice, dims.Y: yslice}
             arct = fac * data.isel(**da_arg)
@@ -247,7 +243,7 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
         elif k == 5:
             fac = 1
             _varName = varName
-            DIMS = [dim for dim in ds[_varName].dims if dim != face]
+            DIMS = [dim for dim in ds[_varName].dims if dim != 'face']
             dims = Dims(DIMS[::-1])
             mask5 = xr.ones_like(ds[_varName].isel(face=arc_cap))
             mask5 = mask5.where(np.logical_and(ds[dims.X] > ds[dims.Y],
@@ -256,7 +252,7 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
             y0, yf = 0, int(len(ds[dims.Y]) / 2)
             xslice = slice(x0, xf)
             yslice = slice(y0, yf)
-            da_arg = {face: arc_cap, dims.X: xslice, dims.Y: yslice}
+            da_arg = {'face': arc_cap, dims.X: xslice, dims.Y: yslice}
             mask_arg = {dims.X: xslice, dims.Y: yslice}
             arct = data.isel(**da_arg)
             Mask = mask5.isel(**mask_arg)
@@ -266,7 +262,7 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
         elif k == 7:
             fac = 1
             _varName = varName
-            DIMS = [dim for dim in ds[_varName].dims if dim != face]
+            DIMS = [dim for dim in ds[_varName].dims if dim != 'face']
             dims = Dims(DIMS[::-1])
             dtr = list(dims)[::-1]
             dtr[-1], dtr[-2] = dtr[-2], dtr[-1]
@@ -282,14 +278,14 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
                     fac = - 1
                 if 'mate' in list(ds[_varName].attrs):
                     _varName = ds[_varName].attrs['mate']
-                DIMS = [dim for dim in ds[_varName].dims if dim != face]
+                DIMS = [dim for dim in ds[_varName].dims if dim != 'face']
                 dims = Dims(DIMS[::-1])
                 dtr = list(dims)[::-1]
                 dtr[-1], dtr[-2] = dtr[-2], dtr[-1]
-                mask7 = xr.ones_like(ds[_varName].isel(face=arc_cap))
+                mask7 = xr.ones_like(ds[_varName].isel(facedim.X=arc_cap))
                 mask7 = mask7.where(np.logical_and(ds[dims.X] > ds[dims.Y],
                                     ds[dims.X] > len(ds[dims.Y]) - ds[dims.Y]))
-            da_arg = {face: arc_cap, dims.X: xslice, dims.Y: yslice}
+            da_arg = {'face': arc_cap, dims.X: xslice, dims.Y: yslice}
             mask_arg = {dims.X: xslice, dims.Y: yslice}
             arct = fac * ds[_varName].isel(**da_arg)
             Mask = mask7.isel(**mask_arg)
@@ -299,7 +295,7 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
         elif k == 10:
             fac = 1
             _varName = varName
-            DIMS = [dim for dim in ds[_varName].dims if dim != face]
+            DIMS = [dim for dim in ds[_varName].dims if dim != 'face']
             dims = Dims(DIMS[::-1])
             mask10 = xr.ones_like(ds[_varName].isel(face=arc_cap))
             mask10 = mask10.where(np.logical_and(ds[dims.X] < ds[dims.Y],
@@ -311,7 +307,7 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
             if len(dims.X) + len(dims.Y) == 4:
                 if _varName not in metrics:
                     fac = -1
-            da_arg = {face: arc_cap, dims.X: xslice, dims.Y: yslice}
+            da_arg = {'face': arc_cap, dims.X: xslice, dims.Y: yslice}
             sort_arg = {'variables': [dims.X], 'ascending': False}
             mask_arg = {dims.X: xslice, dims.Y: yslice}
             arct = fac * ds[_varName].isel(**da_arg)

--- a/xmitgcm/llcreader/llcmodel.py
+++ b/xmitgcm/llcreader/llcmodel.py
@@ -197,6 +197,7 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
         arct_facet: New arctic cap data into a new facet, associated with
                     varName
     '''
+    arc_cap = 6
     ARCT = []
     afaces = [2, 5, 7, 10]  # order of faces with which artic cap connects
     for k in afaces:

--- a/xmitgcm/llcreader/llcmodel.py
+++ b/xmitgcm/llcreader/llcmodel.py
@@ -282,7 +282,7 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
                 dims = Dims(DIMS[::-1])
                 dtr = list(dims)[::-1]
                 dtr[-1], dtr[-2] = dtr[-2], dtr[-1]
-                mask7 = xr.ones_like(ds[_varName].isel(facedim.X=arc_cap))
+                mask7 = xr.ones_like(ds[_varName].isel(face=arc_cap))
                 mask7 = mask7.where(np.logical_and(ds[dims.X] > ds[dims.Y],
                                     ds[dims.X] > len(ds[dims.Y]) - ds[dims.Y]))
             da_arg = {'face': arc_cap, dims.X: xslice, dims.Y: yslice}

--- a/xmitgcm/llcreader/llcmodel.py
+++ b/xmitgcm/llcreader/llcmodel.py
@@ -207,9 +207,8 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
             dims = Dims(DIMS[::-1])
             dtr = list(dims)[::-1]
             dtr[-1], dtr[-2] = dtr[-2], dtr[-1]
-            mask2 = _xr.ones_like(ds[_varName].isel(face=arc_cap))
-            # TODO: Eval where, define argument outside
-            mask2 = mask2.where(_np.logical_and(ds[dims.X] < ds[dims.Y],
+            mask2 = xr.ones_like(ds[_varName].isel(face=arc_cap))
+            mask2 = mask2.where(np.logical_and(ds[dims.X] < ds[dims.Y],
                                 ds[dims.X] < len(ds[dims.Y]) - ds[dims.Y]))
             x0, xf = 0, int(len(ds[dims.Y]) / 2)
             y0, yf = 0, int(len(ds[dims.X]))
@@ -227,8 +226,8 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
                 dims = Dims(_DIMS[::-1])
                 dtr = list(dims)[::-1]
                 dtr[-1], dtr[-2] = dtr[-2], dtr[-1]
-                mask2 = _xr.ones_like(ds[_varName].isel(face=arc_cap))
-                mask2 = mask2.where(_np.logical_and(ds[dims.X] < ds[dims.Y],
+                mask2 = xr.ones_like(ds[_varName].isel(face=arc_cap))
+                mask2 = mask2.where(np.logical_and(ds[dims.X] < ds[dims.Y],
                                     ds[dims.X] < len(ds[dims.Y]) - ds[dims.Y]))
                 da_arg = {'face': arc_cap, dims.X: xslice, dims.Y: yslice}
                 sort_arg = {'variables': dims.Y, 'ascending': False}
@@ -245,8 +244,8 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
             _varName = varName
             DIMS = [dim for dim in ds[_varName].dims if dim != 'face']
             dims = Dims(DIMS[::-1])
-            mask5 = _xr.ones_like(ds[_varName].isel(face=arc_cap))
-            mask5 = mask5.where(_np.logical_and(ds[dims.X] > ds[dims.Y],
+            mask5 = xr.ones_like(ds[_varName].isel(face=arc_cap))
+            mask5 = mask5.where(np.logical_and(ds[dims.X] > ds[dims.Y],
                                 ds[dims.X] < len(ds[dims.Y]) - ds[dims.Y]))
             x0, xf = 0, int(len(ds[dims.X]))
             y0, yf = 0, int(len(ds[dims.Y]) / 2)
@@ -266,15 +265,13 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
             dims = Dims(DIMS[::-1])
             dtr = list(dims)[::-1]
             dtr[-1], dtr[-2] = dtr[-2], dtr[-1]
-            mask7 = _xr.ones_like(ds[_varName].isel(face=arc_cap))
-            mask7 = mask7.where(_np.logical_and(ds[dims.X] > ds[dims.Y],
+            mask7 = xr.ones_like(ds[_varName].isel(face=arc_cap))
+            mask7 = mask7.where(np.logical_and(ds[dims.X] > ds[dims.Y],
                                 ds[dims.X] > len(ds[dims.Y]) - ds[dims.Y]))
             x0, xf = int(len(ds[dims.Y]) / 2), int(len(ds[dims.Y]))
             y0, yf = 0, int(len(ds[dims.X]))
             xslice = slice(x0, xf)
             yslice = slice(y0, yf)
-            Nx_ac_rot.append(len(ds[dims.Y][x0:xf]))
-            Ny_ac_rot.append(0)
             if len(dims.X) + len(dims.Y) == 4:  # vector field
                 if len(dims.X) == 1 and _varName not in metrics:
                     fac = - 1
@@ -284,8 +281,8 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
                 dims = Dims(DIMS[::-1])
                 dtr = list(dims)[::-1]
                 dtr[-1], dtr[-2] = dtr[-2], dtr[-1]
-                mask7 = _xr.ones_like(ds[_varName].isel(face=arc_cap))
-                mask7 = mask7.where(_np.logical_and(ds[dims.X] > ds[dims.Y],
+                mask7 = xr.ones_like(ds[_varName].isel(face=arc_cap))
+                mask7 = mask7.where(np.logical_and(ds[dims.X] > ds[dims.Y],
                                     ds[dims.X] > len(ds[dims.Y]) - ds[dims.Y]))
             da_arg = {'face': arc_cap, dims.X: xslice, dims.Y: yslice}
             mask_arg = {dims.X: xslice, dims.Y: yslice}
@@ -299,8 +296,8 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
             _varName = varName
             DIMS = [dim for dim in ds[_varName].dims if dim != 'face']
             dims = Dims(DIMS[::-1])
-            mask10 = _xr.ones_like(ds[_varName].isel(face=arc_cap))
-            mask10 = mask10.where(_np.logical_and(ds[dims.X] < ds[dims.Y],
+            mask10 = xr.ones_like(ds[_varName].isel(face=arc_cap))
+            mask10 = mask10.where(np.logical_and(ds[dims.X] < ds[dims.Y],
                                   ds[dims.X] > len(ds[dims.Y]) - ds[dims.Y]))
             x0, xf = 0, int(len(ds[dims.X]))
             y0, yf = int(len(ds[dims.Y]) / 2), int(len(ds[dims.Y]))

--- a/xmitgcm/llcreader/llcmodel.py
+++ b/xmitgcm/llcreader/llcmodel.py
@@ -471,18 +471,18 @@ def faces_dataset_to_latlon(ds, metric_vector_pairs=[('dxC', 'dyC'), ('dyG', 'dx
 
     for vname_u, vname_v in vector_pairs:
         data_u, data_v = _faces_to_latlon_vector(ds[vname_u].data, ds[vname_v].data)
-        adata_u = np.nan * _arct_crown(ds, vname_u)  # test with scalars first
+        adata_u = _arct_crown(ds, vname_u)  # test with scalars first
         data_u = concatenate([data_u, adata_u], axis=-2)
-        adata_v = np.nan * _arct_crown(ds, vname_v)  # test with scalars first
+        adata_v = _arct_crown(ds, vname_v)  # test with scalars first
         data_v = concatenate([data_v, adata_v], axis=-2)
         data_vars[vname_u] = xr.Variable(_drop_facedim(ds[vname_u].dims), data_u, ds[vname_u].attrs)
         data_vars[vname_v] = xr.Variable(_drop_facedim(ds[vname_v].dims), data_v, ds[vname_v].attrs)
     for vname_u, vname_v in metric_vector_pairs:
         data_u, data_v = _faces_to_latlon_vector(ds[vname_u].data, ds[vname_v].data, metric=True)
-        adata_u = np.nan * _arct_crown(ds, vname_u)  # not yet vector fields
+        adata_u = _arct_crown(ds, vname_u)  # not yet vector fields
         data_u = concatenate([data_u, adata_u], axis=-2)
         data_vars[vname_u] = xr.Variable(_drop_facedim(ds[vname_u].dims), data_u, ds[vname_u].attrs)
-        adata_v = np.nan * _arct_crown(ds, vname_v)  # not yet vector fields
+        adata_v = _arct_crown(ds, vname_v)  # not yet vector fields
         data_v = concatenate([data_v, adata_v], axis=-2)
         data_vars[vname_v] = xr.Variable(_drop_facedim(ds[vname_v].dims), data_v, ds[vname_v].attrs)
 

--- a/xmitgcm/llcreader/llcmodel.py
+++ b/xmitgcm/llcreader/llcmodel.py
@@ -221,8 +221,8 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
             if len(dims.X) + len(dims.Y) == 4:  # vector field or metric
                 if len(dims.Y) == 1 and _varName not in metrics:
                     fac = - 1
-                if 'mates' in list(ds[_varName].attrs):
-                    _varName = ds[_varName].attrs['mates']
+                if 'mate' in list(ds[_varName].attrs):
+                    _varName = ds[_varName].attrs['mate']
                 _DIMS = [dim for dim in ds[_varName].dims if dim != 'face']
                 dims = Dims(_DIMS[::-1])
                 dtr = list(dims)[::-1]
@@ -278,8 +278,8 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
             if len(dims.X) + len(dims.Y) == 4:  # vector field
                 if len(dims.X) == 1 and _varName not in metrics:
                     fac = - 1
-                if 'mates' in list(ds[_varName].attrs):
-                    _varName = ds[_varName].attrs['mates']
+                if 'mate' in list(ds[_varName].attrs):
+                    _varName = ds[_varName].attrs['mate']
                 DIMS = [dim for dim in ds[_varName].dims if dim != 'face']
                 dims = Dims(DIMS[::-1])
                 dtr = list(dims)[::-1]

--- a/xmitgcm/llcreader/llcmodel.py
+++ b/xmitgcm/llcreader/llcmodel.py
@@ -233,7 +233,7 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
                 da_arg = {'face': arc_cap, dims.X: xslice, dims.Y: yslice}
                 sort_arg = {'variables': dims.Y, 'ascending': False}
                 mask_arg = {dims.X: xslice, dims.Y: yslice}
-            arct = fac * data.isel(**da_arg)
+            arct = fac * ds[_varName].isel(**da_arg)
             arct = arct.sortby(**sort_arg)
             Mask = mask2.isel(**mask_arg)
             Mask = Mask.sortby(**sort_arg)
@@ -254,7 +254,7 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
             yslice = slice(y0, yf)
             da_arg = {'face': arc_cap, dims.X: xslice, dims.Y: yslice}
             mask_arg = {dims.X: xslice, dims.Y: yslice}
-            arct = data.isel(**da_arg)
+            arct = ds[_varName].isel(**da_arg)
             Mask = mask5.isel(**mask_arg)
             arct = (arct * Mask)
             ARCT.append(arct)

--- a/xmitgcm/llcreader/llcmodel.py
+++ b/xmitgcm/llcreader/llcmodel.py
@@ -240,7 +240,7 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
             arct = arct.sortby(**sort_arg)
             Mask = mask2.isel(**mask_arg)
             Mask = Mask.sortby(**sort_arg)
-            arct = (arct * Mask).transpose(*dtr)
+            arct = (arct * Mask).transpose(*dtr, transpose_coords=False)
             ARCT.append(arct)
 
         elif k == 5:
@@ -292,7 +292,7 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
             mask_arg = {dims.X: xslice, dims.Y: yslice}
             arct = fac * ds[_varName].isel(**da_arg)
             Mask = mask7.isel(**mask_arg)
-            arct = (arct * Mask).transpose(*dtr)
+            arct = (arct * Mask).transpose(*dtr, transpose_coords=False)
             ARCT.append(arct)
 
         elif k == 10:

--- a/xmitgcm/llcreader/llcmodel.py
+++ b/xmitgcm/llcreader/llcmodel.py
@@ -440,13 +440,13 @@ def faces_dataset_to_latlon(ds, metric_vector_pairs=[('dxC', 'dyC'), ('dyG', 'dx
     vector_pairs = []
     scalars = []
     vnames = list(ds.reset_coords().variables)
-    # for vname in vnames:
-    #     try:
-    #         mate = ds[vname].attrs['mate']
-    #         vector_pairs.append((vname, mate))
-    #         vnames.remove(mate)
-    #     except KeyError:
-    #         pass
+    for vname in vnames:
+        try:
+            mate = ds[vname].attrs['mate']
+            vector_pairs.append((vname, mate))
+            # vnames.remove(mate)
+        except KeyError:
+            pass
 
     all_vector_components = [inner for outer in (vector_pairs + metric_vector_pairs)
                              for inner in outer]

--- a/xmitgcm/llcreader/llcmodel.py
+++ b/xmitgcm/llcreader/llcmodel.py
@@ -197,6 +197,10 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
         arct_facet: New arctic cap data into a new facet, associated with
                     varName
     '''
+    if 'tile' in ds.dims:
+        face = 'tile'
+    else:
+        face = 'face'
     arc_cap = 6
     ARCT = []
     afaces = [2, 5, 7, 10]  # order of faces with which artic cap connects
@@ -204,7 +208,7 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
         if k == 2:
             fac = 1
             _varName = varName  # copy, b/c varName may change
-            DIMS = [dim for dim in ds[_varName].dims if dim != 'face']
+            DIMS = [dim for dim in ds[_varName].dims if dim != face]
             dims = Dims(DIMS[::-1])
             dtr = list(dims)[::-1]
             dtr[-1], dtr[-2] = dtr[-2], dtr[-1]
@@ -215,7 +219,7 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
             y0, yf = 0, int(len(ds[dims.X]))
             xslice = slice(x0, xf)
             yslice = slice(y0, yf)
-            da_arg = {'face': arc_cap, dims.X: xslice, dims.Y: yslice}
+            da_arg = {face: arc_cap, dims.X: xslice, dims.Y: yslice}
             sort_arg = {'variables': dims.Y, 'ascending': False}
             mask_arg = {dims.X: xslice, dims.Y: yslice}
             if len(dims.X) + len(dims.Y) == 4:  # vector field or metric
@@ -223,14 +227,14 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
                     fac = - 1
                 if 'mate' in list(ds[_varName].attrs):
                     _varName = ds[_varName].attrs['mate']
-                _DIMS = [dim for dim in ds[_varName].dims if dim != 'face']
+                _DIMS = [dim for dim in ds[_varName].dims if dim != face]
                 dims = Dims(_DIMS[::-1])
                 dtr = list(dims)[::-1]
                 dtr[-1], dtr[-2] = dtr[-2], dtr[-1]
                 mask2 = xr.ones_like(ds[_varName].isel(face=arc_cap))
                 mask2 = mask2.where(np.logical_and(ds[dims.X] < ds[dims.Y],
                                     ds[dims.X] < len(ds[dims.Y]) - ds[dims.Y]))
-                da_arg = {'face': arc_cap, dims.X: xslice, dims.Y: yslice}
+                da_arg = {face: arc_cap, dims.X: xslice, dims.Y: yslice}
                 sort_arg = {'variables': dims.Y, 'ascending': False}
                 mask_arg = {dims.X: xslice, dims.Y: yslice}
             arct = fac * data.isel(**da_arg)
@@ -243,7 +247,7 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
         elif k == 5:
             fac = 1
             _varName = varName
-            DIMS = [dim for dim in ds[_varName].dims if dim != 'face']
+            DIMS = [dim for dim in ds[_varName].dims if dim != face]
             dims = Dims(DIMS[::-1])
             mask5 = xr.ones_like(ds[_varName].isel(face=arc_cap))
             mask5 = mask5.where(np.logical_and(ds[dims.X] > ds[dims.Y],
@@ -252,7 +256,7 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
             y0, yf = 0, int(len(ds[dims.Y]) / 2)
             xslice = slice(x0, xf)
             yslice = slice(y0, yf)
-            da_arg = {'face': arc_cap, dims.X: xslice, dims.Y: yslice}
+            da_arg = {face: arc_cap, dims.X: xslice, dims.Y: yslice}
             mask_arg = {dims.X: xslice, dims.Y: yslice}
             arct = data.isel(**da_arg)
             Mask = mask5.isel(**mask_arg)
@@ -262,7 +266,7 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
         elif k == 7:
             fac = 1
             _varName = varName
-            DIMS = [dim for dim in ds[_varName].dims if dim != 'face']
+            DIMS = [dim for dim in ds[_varName].dims if dim != face]
             dims = Dims(DIMS[::-1])
             dtr = list(dims)[::-1]
             dtr[-1], dtr[-2] = dtr[-2], dtr[-1]
@@ -278,14 +282,14 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
                     fac = - 1
                 if 'mate' in list(ds[_varName].attrs):
                     _varName = ds[_varName].attrs['mate']
-                DIMS = [dim for dim in ds[_varName].dims if dim != 'face']
+                DIMS = [dim for dim in ds[_varName].dims if dim != face]
                 dims = Dims(DIMS[::-1])
                 dtr = list(dims)[::-1]
                 dtr[-1], dtr[-2] = dtr[-2], dtr[-1]
                 mask7 = xr.ones_like(ds[_varName].isel(face=arc_cap))
                 mask7 = mask7.where(np.logical_and(ds[dims.X] > ds[dims.Y],
                                     ds[dims.X] > len(ds[dims.Y]) - ds[dims.Y]))
-            da_arg = {'face': arc_cap, dims.X: xslice, dims.Y: yslice}
+            da_arg = {face: arc_cap, dims.X: xslice, dims.Y: yslice}
             mask_arg = {dims.X: xslice, dims.Y: yslice}
             arct = fac * ds[_varName].isel(**da_arg)
             Mask = mask7.isel(**mask_arg)
@@ -295,7 +299,7 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
         elif k == 10:
             fac = 1
             _varName = varName
-            DIMS = [dim for dim in ds[_varName].dims if dim != 'face']
+            DIMS = [dim for dim in ds[_varName].dims if dim != face]
             dims = Dims(DIMS[::-1])
             mask10 = xr.ones_like(ds[_varName].isel(face=arc_cap))
             mask10 = mask10.where(np.logical_and(ds[dims.X] < ds[dims.Y],
@@ -307,7 +311,7 @@ def _arct_crown(ds, varName, metrics=['dxC', 'dyC', 'dxG', 'dyG']):
             if len(dims.X) + len(dims.Y) == 4:
                 if _varName not in metrics:
                     fac = -1
-            da_arg = {'face': arc_cap, dims.X: xslice, dims.Y: yslice}
+            da_arg = {face: arc_cap, dims.X: xslice, dims.Y: yslice}
             sort_arg = {'variables': [dims.X], 'ascending': False}
             mask_arg = {dims.X: xslice, dims.Y: yslice}
             arct = fac * ds[_varName].isel(**da_arg)

--- a/xmitgcm/test/test_llcreader.py
+++ b/xmitgcm/test/test_llcreader.py
@@ -6,10 +6,11 @@ llcreader = pytest.importorskip("xmitgcm.llcreader")
 from .test_xmitgcm_common import llc_mds_datadirs
 
 EXPECTED_VARS = ['Eta', 'KPPhbl', 'oceFWflx', 'oceQnet', 'oceQsw', 'oceSflux',
-            'oceTAUX', 'oceTAUY', 'PhiBot', 'Salt', 'SIarea', 'SIheff',
-            'SIhsalt', 'SIhsnow', 'SIuice', 'SIvice', 'Theta', 'U', 'V', 'W']
+                 'oceTAUX', 'oceTAUY', 'PhiBot', 'Salt', 'SIarea', 'SIheff',
+                 'SIhsalt', 'SIhsnow', 'SIuice', 'SIvice', 'Theta', 'U', 'V',
+                 'W']
 
-EXPECTED_COORDS = {2160: ['CS','SN','Depth',
+EXPECTED_COORDS = {2160: ['CS', 'SN', 'Depth',
                           'drC','drF','dxC','dxF','dxG','dyC','dyF','dyG',
                           'hFacC','hFacS','hFacW','PHrefC','PHrefF','rA','rAs','rAw',
                           'Z','Zp1','Zl','Zu','rhoRef','rLowC','rLowS','rLowW',
@@ -40,8 +41,9 @@ def test_llc90_local_faces(local_llc90_store, llc90_kwargs):
     model = llcreader.LLC90Model(store)
     ds_faces = model.get_dataset(**llc90_kwargs)
     assert set(llc90_kwargs['varnames']) == set(ds_faces.data_vars)
-    assert ds_faces.dims == {'face': 13, 'i': 90, 'i_g': 90, 'j': 90, 'j_g': 90,
-                             'k': 50, 'k_u': 50, 'k_l': 50, 'k_p1': 51, 'time': 2}
+    assert ds_faces.dims == {'face': 13, 'i': 90, 'i_g': 90, 'j': 90,
+                             'j_g': 90, 'k': 50, 'k_u': 50, 'k_l': 50,
+                             'k_p1': 51, 'time': 2}
 
 def test_llc90_local_latlon(local_llc90_store, llc90_kwargs):
     store = local_llc90_store
@@ -50,13 +52,13 @@ def test_llc90_local_latlon(local_llc90_store, llc90_kwargs):
     assert set(llc90_kwargs['varnames']) == set(ds_latlon.data_vars)
     assert ds_latlon.dims == {'i': 360, 'time': 2, 'k_p1': 51, 'face': 13,
                               'i_g': 360, 'k_u': 50, 'k': 50, 'k_l': 50,
-                              'j_g': 270, 'j': 270}
+                              'j_g': 315, 'j': 315}
 
 @pytest.mark.parametrize('rettype', ['faces', 'latlon'])
 @pytest.mark.parametrize('k_levels, kp1_levels',
-        [(None,None),
+        [(None, None),
          ([0, 2, 7, 9, 10, 20],
-          [0,1,2,3,7,8,9,10,11,20,21])])
+          [0, 1, 2, 3, 7, 8, 9, 10, 11, 20, 21])])
 @pytest.mark.parametrize('k_chunksize', [1, 2])
 def test_llc90_local_faces_load(local_llc90_store, llc90_kwargs, rettype, k_levels,
                                 kp1_levels, k_chunksize):
@@ -74,7 +76,7 @@ def test_llc90_local_faces_load(local_llc90_store, llc90_kwargs, rettype, k_leve
 
     ds.load()
 
-########### ECCO Portal Tests ##################################################
+########### ECCO Portal Tests##################################################
 
 @pytest.fixture(scope='module', params=[2160, 4320])
 def ecco_portal_model(request):
@@ -113,9 +115,9 @@ def test_ecco_portal_latlon(ecco_portal_model):
     iter_stop = ecco_portal_model.iter_start + 2 * ecco_portal_model.iter_step + 1
     ds_ll = ecco_portal_model.get_dataset(iter_stop=iter_stop, type='latlon')
     nx = ecco_portal_model.nx
-    assert ds_ll.dims == {'i': 4*nx, 'k_u': 90, 'k_l': 90, 'time': 3,
-                             'k': 90, 'j_g': 3*nx, 'i_g': 4*nx, 'k_p1': 91,
-                             'j': 3*nx, 'face': 13}
+    assert ds_ll.dims == {'i': 4 * nx, 'k_u': 90, 'k_l': 90, 'time': 3,
+                          'k': 90, 'j_g': int(3.5 * nx), 'i_g': 4 * nx,
+                          'k_p1': 91, 'j': int(3.5 * nx), 'face': 13}
     assert set(EXPECTED_VARS) == set(ds_ll.data_vars)
     assert set(EXPECTED_COORDS[nx]).issubset(set(ds_ll.coords))
 


### PR DESCRIPTION
Here is an initial pull request of my code which facilitates including data from the arctic cap (facet) into a transformed array which no longer has 'face' as a dimension. Before, data was transformed into a single (rectangular) array with data from the arctic cap missing. Now, arctic is included as a form of 'crown', which is done by splitting the arctic data into four different (triangular) regions and concatenating each triangular region with the corresponding facet with which these 'exchange' data. Below is an example of LLC4320 data transformed using my xmitgcm fork


![arctic_crown_LLC4320](https://user-images.githubusercontent.com/8241481/87729534-9dd01080-c793-11ea-9815-5500a7ec4a9f.png)

This pull request should close #199 .

I must mention that I have a more general code that allows for transformation of a subset of faces (as long as these are contiguous) into a single array with face no longer a dimension, as opposed to all the faces. This allows for an economic version of the transformation since not all data is needed, nor transformed. In addition, I have also created a transformation that is centered around the arctic, creating an array that resembles a polar projection centered on the north pole. This is in my repository https://github.com/Mikejmnez/llc_transformations, and there you can find an example notebook. I would be interested in including such code in ```llcreader```, but would take some time to figure out the best way to do so, and of course some guidance.

cheers!
Miguel


