### PR TITLE
python 2.7 env with old zarr

### DIFF
--- a/ci/environment-py2.7.yml
+++ b/ci/environment-py2.7.yml
@@ -7,7 +7,7 @@ dependencies:
   - pytest
   - future
   - cftime
-  - zarr
+  - zarr<=2.3.2
   - pip:
     - cachetools
     - codecov

--- a/ci/environment-py2.7.yml
+++ b/ci/environment-py2.7.yml
@@ -7,7 +7,7 @@ dependencies:
   - pytest
   - future
   - cftime
-  - zarr<=2.3.2
+  - zarr
   - pip:
     - cachetools
     - codecov

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,6 @@ CLASSIFIERS = [
 INSTALL_REQUIRES = ['xarray >= 0.10.1', 'dask >= 1.0', 'cachetools']
 SETUP_REQUIRES = ['pytest-runner']
 TESTS_REQUIRE = ['pytest >= 4.0', 'coverage']
-if sys.version_info < (2,7):
-    TESTS_REQUIRE+=['zarr<=2.3.2']
 
 DESCRIPTION = "Read MITgcm mds binary files into xarray"
 def readme():

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ CLASSIFIERS = [
 INSTALL_REQUIRES = ['xarray >= 0.10.1', 'dask >= 1.0', 'cachetools']
 SETUP_REQUIRES = ['pytest-runner']
 TESTS_REQUIRE = ['pytest >= 4.0', 'coverage']
+if sys.version_info < (2,7):
+    TESTS_REQUIRE+=['zarr<=2.3.2']
 
 DESCRIPTION = "Read MITgcm mds binary files into xarray"
 def readme():


### PR DESCRIPTION
Current python 2.7 tests break because of zarr, which has not supported python 2 since version 2.3.2. This PR specifies `zarr<=2.3.2` in the ci/environment file.