### PR TITLE
Lazy open_mdsdataset with recent xarray versions.

### DIFF
--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -238,7 +238,7 @@ def open_mdsdataset(data_dir, grid_dir=None,
                 elif xr.__version__ < '0.15.2':
                     ds = xr.combine_by_coords(datasets)
                 else:
-                    ds = xr.combine_by_coords(datasets,combine_attrs='drop')
+                    ds = xr.combine_by_coords(datasets, compat='override', coords='minimal', combine_attrs='drop')
 
                 if swap_dims:
                     ds = _swap_dimensions(ds, geometry)


### PR DESCRIPTION
Fixes #229 by skipping conflict checks when merging datasets.

I'm not 100% sure this does not break something, but it didn't break the tests on my machine!