### PR TITLE
fixed probable typo for 'coordinate' entry in dimensions dictionary

### DIFF
--- a/xmitgcm/variables.py
+++ b/xmitgcm/variables.py
@@ -76,7 +76,7 @@ horizontal_coordinates_spherical = OrderedDict(
         units="degrees_east", coordinate="YG XG")),
     YG=dict(dims=["j_g", "i_g"], attrs=dict(
         standard_name="latitude_at_f_location", long_name="latitude",
-        units="degrees_north", coordinates="YG XG"))
+        units="degrees_north", coordinate="YG XG"))
 )
 
 horizontal_coordinates_llc = horizontal_coordinates_spherical.copy()
@@ -102,7 +102,7 @@ horizontal_coordinates_curvcart = OrderedDict(
         long_name="x coordinate", units="m", coordinate="YG XG")),
     YG=dict(dims=["j_g", "i_g"], attrs=dict(
         standard_name="plane_y_coordinate_at_f_location",
-        long_name="y coordinate", units="m", coordinates="YG XG")),
+        long_name="y coordinate", units="m", coordinate="YG XG")),
     CS=dict(dims=["j", "i"], attrs=dict(standard_name="Cos of grid orientation angle",
                                         long_name="AngleCS", units=" ", coordinate="YC XC"),
             filename='AngleCS'),
@@ -123,7 +123,7 @@ horizontal_coordinates_cartesian = OrderedDict(
         long_name="x coordinate", units="m", coordinate="YG XG")),
     YG=dict(dims=["j_g", "i_g"], attrs=dict(
         standard_name="plane_y_coordinate_at_f_location",
-        long_name="y coordinate", units="m", coordinates="YG XG"))
+        long_name="y coordinate", units="m", coordinate="YG XG"))
 )
 
 vertical_coordinates = OrderedDict(
@@ -186,7 +186,7 @@ horizontal_grid_variables = OrderedDict(
     # v cell
     rAs=dict(dims=["j_g", "i"], attrs=dict(
         standard_name="cell_area_at_v_location",
-        long_name="cell area", units="m2", coordinates="YG XC"),
+        long_name="cell area", units="m2", coordinate="YG XC"),
         filename='RAS'),
 )
 


### PR DESCRIPTION
convention here seems to be

    XC=dict(dims=["j", "i"], attrs=dict(
        standard_name="longitude", long_name="longitude",
        units="degrees_east", coordinate="YC XC")),

some instances fixed where "coordinate" was spelled "coordinates".  May have no effect.