### PR TITLE
feat: IMPLEMENTS CHECKING FOR VARIABLE MATES

### DIFF
--- a/xmitgcm/llcreader/llcmodel.py
+++ b/xmitgcm/llcreader/llcmodel.py
@@ -298,13 +298,21 @@ def faces_dataset_to_latlon(ds, metric_vector_pairs=[('dxC', 'dyC'), ('dyG', 'dx
     vector_pairs = []
     scalars = []
     vnames = list(ds.reset_coords().variables)
+
     for vname in vnames:
         try:
             mate = ds[vname].attrs['mate']
-            vector_pairs.append((vname, mate))
-            vnames.remove(mate)
         except KeyError:
-            pass
+            mate = None
+
+        # Raises an exception if the mate of a variable in vnames is missing.
+        if mate is not None:
+            vector_pairs.append((vname, mate))
+            try:
+                vnames.remove(mate)
+            except ValueError:
+                msg = 'If {} in varnames, {} must also be in varnames'.format(vname, mate)
+                raise ValueError(msg)
 
     all_vector_components = [inner for outer in (vector_pairs + metric_vector_pairs)
                              for inner in outer]
@@ -349,13 +357,21 @@ def _all_facets_to_latlon(data_facets, meta):
     vector_pairs = []
     scalars = []
     vnames = list(data_facets)
+
     for vname in vnames:
         try:
             mate = meta[vname]['attrs']['mate']
-            vector_pairs.append((vname, mate))
-            vnames.remove(mate)
         except KeyError:
-            pass
+            mate = None
+
+        # Raises an exception if the mate of a variable in vnames is missing.
+        if mate is not None:
+            vector_pairs.append((vname, mate))
+            try:
+                vnames.remove(mate)
+            except ValueError:
+                msg = 'If {} in varnames, {} must also be in varnames'.format(vname, mate)
+                raise ValueError(msg)
 
     all_vector_components = [inner for outer in vector_pairs for inner in outer]
     scalars = [vname for vname in vnames if vname not in all_vector_components]

--- a/xmitgcm/test/test_llcreader.py
+++ b/xmitgcm/test/test_llcreader.py
@@ -74,6 +74,15 @@ def test_llc90_local_faces_load(local_llc90_store, llc90_kwargs, rettype, k_leve
 
     ds.load()
 
+
+@pytest.mark.parametrize('varname', ['U', 'V'])
+def test_vector_mate_error(local_llc90_store, varname):
+    store = local_llc90_store
+    model = llcreader.LLC90Model(store)
+    with pytest.raises(ValueError, match=r".* must also be .*"):
+        ds_latlon = model.get_dataset(type='latlon', varnames=varname, iter_start=0, iter_stop=9, iter_step=8)
+
+
 ########### ECCO Portal Tests ##################################################
 
 @pytest.fixture(scope='module', params=[2160, 4320])

--- a/xmitgcm/test/test_llcreader.py
+++ b/xmitgcm/test/test_llcreader.py
@@ -75,12 +75,12 @@ def test_llc90_local_faces_load(local_llc90_store, llc90_kwargs, rettype, k_leve
     ds.load()
 
 
-#@pytest.mark.parametrize('varname', ['U', 'V'])
-#def test_vector_mate_error(local_llc90_store, varname):
-#    store = local_llc90_store
-#    model = llcreader.LLC90Model(store)
-#    with pytest.raises(ValueError, match=r".* must also be .*"):
-#        ds_latlon = model.get_dataset(type='latlon', varnames=varname, iter_start=0, iter_stop=9, iter_step=8)
+@pytest.mark.parametrize('varname', [['U'], ['V']])
+def test_vector_mate_error(local_llc90_store, varname):
+    store = local_llc90_store
+    model = llcreader.LLC90Model(store)
+    with pytest.raises(ValueError, match=r".* must also be .*"):
+        ds_latlon = model.get_dataset(type='latlon', varnames=varname, iter_start=0, iter_stop=9, iter_step=8)
 
 
 ########### ECCO Portal Tests ##################################################

--- a/xmitgcm/test/test_llcreader.py
+++ b/xmitgcm/test/test_llcreader.py
@@ -75,12 +75,12 @@ def test_llc90_local_faces_load(local_llc90_store, llc90_kwargs, rettype, k_leve
     ds.load()
 
 
-@pytest.mark.parametrize('varname', ['U', 'V'])
-def test_vector_mate_error(local_llc90_store, varname):
-    store = local_llc90_store
-    model = llcreader.LLC90Model(store)
-    with pytest.raises(ValueError, match=r".* must also be .*"):
-        ds_latlon = model.get_dataset(type='latlon', varnames=varname, iter_start=0, iter_stop=9, iter_step=8)
+#@pytest.mark.parametrize('varname', ['U', 'V'])
+#def test_vector_mate_error(local_llc90_store, varname):
+#    store = local_llc90_store
+#    model = llcreader.LLC90Model(store)
+#    with pytest.raises(ValueError, match=r".* must also be .*"):
+#        ds_latlon = model.get_dataset(type='latlon', varnames=varname, iter_start=0, iter_stop=9, iter_step=8)
 
 
 ########### ECCO Portal Tests ##################################################


### PR DESCRIPTION
On a latlon LLC grid some variables have mates. This commit will produce a meaningful error if attempting to use `get_dataset` or `faces_dataset_to_latlon` to load a variable without its mate.

See Github issue #234