### PR TITLE
add a standard set of ADJ variables

### DIFF
--- a/xmitgcm/variables.py
+++ b/xmitgcm/variables.py
@@ -602,8 +602,151 @@ package_state_variables = {
         units='W m-2')),
     'QSWtave': dict(dims=['j', 'i'], attrs=dict(
         standard_name="surface_net_upward_shortwave_flux",
-        long_name='SEAICE upward freshwater flux (+=up)',
-        units='kg m-2 s-1'))
+        long_name='SEAICE upward shortwave heat flux (+=up)',
+        units='W m-2')),
+    # pkg/autodiff variables
+    'ADJtaux': dict(dims=['j', 'i_g'], attrs=dict(
+        standard_name="ADJtaux",
+        long_name='dJ/dtaux: Sensitivity to zonal surface stress',
+        mate='ADJtauy',
+        units='dJ/(N m-2)')),
+    'ADJtauy': dict(dims=['j_g', 'i'], attrs=dict(
+        standard_name="ADJtaux",
+        long_name='dJ/dtauy: Sensitivity to meridional surface stress',
+        mate='ADJtaux',
+        units='dJ/(N m-2)')),
+    'ADJqnet': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="ADJqnet",
+        long_name='dJ/dqnet: Sensitivity to net upward heat flux',
+        units='dJ/(W m-2)')),
+    'ADJempr': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="ADJempr",
+        long_name='dJ/dempr: Sensitivity to upward freshwater flux',
+        units='dJ/(kg m-2 s-1)')),
+    'ADJqsw': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="ADJqsw",
+        long_name='dJ/dqsw: Sensitivity to net upward heat flux',
+        units='dJ/(N m-2)')),
+    'ADJggl90tke': dict(dims=['k', 'j', 'i'], attrs=dict(
+        standard_name="ADJggl90tke",
+        long_name='dJ/dggl90tke: Sensitivity to TKE',
+        units='dJ/(m2 s-2)')),
+    'ADJdiffkr': dict(dims=['k', 'j', 'i'], attrs=dict(
+        standard_name="ADJdiffkr",
+        long_name='dJ/ddiffkr: Sensitivity to vertical diffusivity',
+        units='dJ/(m2 s-1)')),
+    'ADJkapgm': dict(dims=['k', 'j', 'i'], attrs=dict(
+        standard_name="ADJkapgm",
+        long_name='dJ/dkapgm: Sensitivity to meridional surface stress',
+        units='dJ/(m2 s-1)')),
+    'ADJkapredi': dict(dims=['k', 'j', 'i'], attrs=dict(
+        standard_name="ADJkapredi",
+        long_name='dJ/dkapredi: Sensitivity to meridional surface stress',
+        units='dJ/(m2 s-1)')),
+    'ADJeddypsix': dict(dims=['k', 'j', 'i_g'], attrs=dict(
+        standard_name="ADJeddypsix",
+        long_name='dJ/deddypsix: Sensitivity to zonal eddy streamfunction',
+        mate='ADJeddypsiy',
+        units='dJ/(m2 s-1)')),
+    'ADJeddypsiy': dict(dims=['k', 'j_g', 'i'], attrs=dict(
+        standard_name="ADJtaux",
+        long_name='dJ/deddypsiy: Sensitivity to meridional eddy streamfunction',
+        mate='ADJeddypsix',
+        units='dJ/(m2 s-1)')),
+    'ADJsst': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="ADJsst",
+        long_name='dJ/dsst: Sensitivity to sea surface temperature',
+        units='dJ/K')),
+    'ADJsss': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="ADJsss",
+        long_name='dJ/dsss: Sensitivity to sea surface salinity',
+        units='dJ/pss)')),
+    'ADJbottomdrag': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="ADbottomdrag",
+        long_name='dJ/dbottomdrag: Sensitivity to linear bottom drag coeff',
+        units='dJ/(m-1)')),
+    'ADJustress': dict(dims=['j', 'i_g'], attrs=dict(
+        standard_name="ADJustress",
+        long_name='dJ/dustress: Sensitivity to zonal wind stress',
+        mate='ADJvstress',
+        units='dJ/(N m-2)')),
+    'ADJvstress': dict(dims=['j_g', 'i'], attrs=dict(
+        standard_name="ADJvstress",
+        long_name='dJ/dvstress: Sensitivity to meridional wind stress',
+        mate='ADJustress',
+        units='dJ/(N m-2)')),
+    'ADJuwind': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="ADJuwind",
+        long_name='dJ/duwind: Sensitivity to zonal wind',
+        mate='ADJvwind',
+        units='dJ/(m s-1)')),
+    'ADJvwind': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="ADJvwind",
+        long_name='dJ/dvwind: Sensitivity to meridional wind',
+        mate='ADJuwind',
+        units='dJ/(m s-1)')),
+    'ADJatemp': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="ADJatemp",
+        long_name='dJ/datemp: Sensitivity to atmosperic surface temperature',
+        units='dJ/K')),
+    'ADJaqh': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="ADJaqh",
+        long_name='dJ/daqh: Sensitivity to specific surface humidity',
+        units='dJ/K')),
+    'ADJswdown': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="ADJswdown",
+        long_name='dJ/dswdown: Sensitivity to downward solar radiation',
+        units='dJ/(W m-2)')),
+    'ADJlwdown': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="ADJlwdown",
+        long_name='dJ/dswdown: Sensitivity to downward longwave radiation',
+        units='dJ/(W m-2)')),
+    'ADJhflux': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="ADJhflux",
+        long_name='dJ/dswdown: Sensitivity to upward heat flux',
+        units='dJ/(W m-2)')),
+    'ADJsflux': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="ADJsflux",
+        long_name='dJ/dsflux: Sensitivity to upward fresh water flux',
+        units='dJ/(m s-1)')),
+    'ADJprecip': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="ADJprecip",
+        long_name='dJ/dprecip: Sensitivity to precipitation flux',
+        units='dJ/(kg m-2 s-1)')),
+    'ADJrunoff': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="ADJrunoff",
+        long_name='dJ/drunoff: Sensitivity to runoff',
+        units='dJ/(kg m-2 s-1)')),
+    'ADJclimsst': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="ADJclimsst",
+        long_name='dJ/dclimsst: Sensitivity to restoring surface temperature',
+        units='dJ/K')),
+    'ADJclimsss': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="ADJclimsss",
+        long_name='dJ/dclimsss: Sensitivity to restoring surface salinity',
+        units='dJ/pss)')),
+    'ADJarea': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="ADJarea",
+        long_name='dJ/darea: Sensitivity to sea ice concentration',
+        units='dJ')),
+    'ADJheff': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="ADJheff",
+        long_name='dJ/dheff: Sensitivity to sea ice thickness',
+        units='dJ/m')),
+    'ADJhsnow': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="ADJhsnow",
+        long_name='dJ/dhsnow: Sensitivity to snow thickness',
+        units='dJ/m')),
+    'ADJuice': dict(dims=['j', 'i_g'], attrs=dict(
+        standard_name="ADJuice",
+        long_name='dJ/duice: Sensitivity to zonal ice drift',
+        mate='ADJvice',
+        units='dJ/(m s-1)')),
+    'ADJvice': dict(dims=['j_g', 'i'], attrs=dict(
+        standard_name="ADJvice",
+        long_name='dJ/dvice: Sensitivity to meridional ice drift',
+        mate='ADJuice',
+        units='dJ/(m s-1)'))
 }
 
 extra_grid_variables = OrderedDict(


### PR DESCRIPTION
for my ecco-like adjoint simulations, I would like to be able to read the hard coded standard adjoint output (per adjDumpFreq) with xmitgcm. Appending the dict `packages_state_variables` let's me do so.

Also there's s small fix to one variable name and unit.