### PR TITLE
Minor update xarray master CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,7 @@ jobs:
       with:
         activate-environment: test_env # Defined in ci/environment-*.yml
         auto-update-conda: false
-        python-version: 3.6
+        python-version: 3.7
         environment-file: ci/environment-py37-xarraymaster.yml
         use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
     - name: Set up conda environment


### PR DESCRIPTION
I noticed my fork's master, xarray-master build failed to pass checks: https://github.com/timothyas/xmitgcm/runs/2344997019

This is fixed by updating the python version specified to GitHub Actions from 3.6 -> 3.7