### PR TITLE
Q: Add exorad flux variable to variables.py

### DIFF
--- a/xmitgcm/variables.py
+++ b/xmitgcm/variables.py
@@ -757,7 +757,12 @@ package_state_variables = {
         standard_name="ADJvice",
         long_name='dJ/dvice: Sensitivity to meridional ice drift',
         mate='ADJuice',
-        units='dJ/(m s-1)'))
+        units='dJ/(m s-1)')),
+    'EXOBFlux': dict(dims=['k_p1','j', 'i'], attrs=dict(
+        standard_name="EXOBFlux",
+        long_name='bolometric radiative flux from exorad',
+        mate='EXOBFlux',
+        units='W/m2')),
 }
 
 extra_grid_variables = OrderedDict(


### PR DESCRIPTION
Hi,

this PR is more of a question. 

We are currently developing a package (called `exorad`) for MITgcm which we plan to publish open source (merge into MITgcm) in the future.

`xmitgcm` is such a useful package when it comes to opening MITgcm output. However (as far as I can see), its restricted to the variables declared in `available_diagnostics.log` and `variables.py`.

Therefore, my question: What would be the best practice? 
- Tell the users of our package to extend their installation of `xmitgcm`
- Merge variable names to `xmitgcm` (e.g. with such a PR) even though our package is yet not public
- add the option for the user to add specific variable names

I apologize if the last option is already implemented and I oversaw it.