### PR TITLE
fix combine_by_coords

### DIFF
--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -259,6 +259,8 @@ def open_mdsdataset(data_dir, grid_dir=None,
                     ds = xr.auto_combine(datasets)
                 elif xr.__version__ < '0.15.2':
                     ds = xr.combine_by_coords(datasets)
+                elif xr.__version__ < '0.18.0':
+                    ds = xr.combine_by_coords(datasets, compat='override', coords='minimal', combine_attrs='drop')
                 else:
                     ds = xr.combine_by_coords(datasets, compat='override', coords='minimal', combine_attrs='drop_conflicts')
 

--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -260,7 +260,7 @@ def open_mdsdataset(data_dir, grid_dir=None,
                 elif xr.__version__ < '0.15.2':
                     ds = xr.combine_by_coords(datasets)
                 else:
-                    ds = xr.combine_by_coords(datasets, compat='override', coords='minimal', combine_attrs='drop')
+                    ds = xr.combine_by_coords(datasets, compat='override', coords='minimal', combine_attrs='drop_conflicts')
 
                 if swap_dims:
                     ds = _swap_dimensions(ds, geometry)

--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -288,7 +288,7 @@ def test_swap_dims(all_mds_datadirs):
                               ['_bounds', '_center', '_interface']]
                 expected_dims += extra_dims
 
-        assert list(ds.dims.keys()) == expected_dims
+        assert set(ds.dims.keys()) == set(expected_dims)
 
         # make sure swapping works with multiple iters
         ds = xmitgcm.open_mdsdataset(dirname, geometry=expected['geometry'],


### PR DESCRIPTION
This PR fixes the `combine_by_coors` call to fix `_swap_dims`.
Closes #265 