### PR TITLE
fix masking for SIuice and SIvice in the same way as for oceTAUX/Y

### DIFF
--- a/xmitgcm/llcreader/known_models.py
+++ b/xmitgcm/llcreader/known_models.py
@@ -56,8 +56,8 @@ class LLC2160Model(BaseLLCModel):
                      'RC','RF','RhoRef','rLowC','rLowS','rLowW',
                      'rSurfC','rSurfS','rSurfW','XC','YC',
                      'RAZ','XG','YG','DXV','DYU']
-    mask_override = {'oceTAUX': 'c', 'oceTAUY': 'c'}
-
+    mask_override = {'oceTAUX': 'c', 'oceTAUY': 'c',
+                     'SIuice':  'c', 'SIvice':  'c'}
 
 class LLC4320Model(BaseLLCModel):
     nx = 4320
@@ -80,7 +80,8 @@ class LLC4320Model(BaseLLCModel):
                      'hFacC','hFacS','hFacW','PHrefC','PHrefF',
                      'RAC','RAS','RAW','RC','RF',
                      'RhoRef','XC','YC','RAZ','XG','YG','DXV','DYU']
-    mask_override = {'oceTAUX': 'c', 'oceTAUY': 'c'}
+    mask_override = {'oceTAUX': 'c', 'oceTAUY': 'c',
+                     'SIuice':  'c', 'SIvice':  'c'}
 
 class ASTE270Model(BaseLLCModel):
     nface = 6


### PR DESCRIPTION
This fixes issue #278 as PR #192 fixed issue #191, by add SIu/vice to mask_override.