### PR TITLE
Use correct mask suffixes

### DIFF
--- a/xmitgcm/llcreader/llcutils.py
+++ b/xmitgcm/llcreader/llcutils.py
@@ -8,7 +8,7 @@ def load_masks_from_mds(grid_dir):
     import xmitgcm
     ds = xmitgcm.open_mdsdataset(grid_dir, iters=None, geometry='llc')
 
-    points = ['W', 'W', 'S']
+    points = ['C', 'W', 'S']
     masks = [ds['hfac' + point].reset_coords(drop=True).rename('mask' + point)
              for point in points]
     ds_mask = xr.merge(masks)


### PR DESCRIPTION
This apparent typo was noted by @mlosch in #278.

It looks severe. However, how could things have possibly worked without it. This really makes me wish we had better test coverage for the llcreader stuff. 🤦 