### PR TITLE
Patches for single face regions

### DIFF
--- a/xmitgcm/utils.py
+++ b/xmitgcm/utils.py
@@ -1105,16 +1105,26 @@ def _read_xy_chunk(variable, file_metadata, rec=0, lev=0, face=0,
 
     # 1. compute offset_variable, init to zero
     offset_vars = 0
-    # loop on variables before the one to read
-    for jvar in np.arange(idx_var):
-        # inspect its dimensions
-        dims = file_metadata['dims_vars'][jvar]
-        # compute the byte size of this variable
+    # if var list is a single element
+    if idx_var == 0:
+        dims = file_metadata['dims_vars']
         nbytes_thisvar = 1*nbytes
         for dim in dims:
             nbytes_thisvar = nbytes_thisvar*file_metadata[dim]
         # update offset from previous variables
         offset_vars = offset_vars+nbytes_thisvar
+
+    # loop on variables before the one to read
+    else:
+        for jvar in np.arange(idx_var):
+            # inspect its dimensions
+            dims = file_metadata['dims_vars'][jvar]
+            # compute the byte size of this variable
+            nbytes_thisvar = 1*nbytes
+            for dim in dims:
+                nbytes_thisvar = nbytes_thisvar*file_metadata[dim]
+            # update offset from previous variables
+            offset_vars = offset_vars+nbytes_thisvar
 
     # 2. get dimensions of desired variable
     dims = file_metadata['dims_vars'][idx_var]
@@ -1292,7 +1302,7 @@ def get_extra_metadata(domain='llc', nx=90):
             'transpose_face': [False, False, False,
                                True, True, True]}
 
-    nesb = {'has_faces': True, 
+    nesb = {'has_faces': False, 
             'ny': 170, 'nx': 220,
             'ny_facets': [0,0,0,0,170],
             'pad_before_y': [0, 0, 0, 0, 2644],

--- a/xmitgcm/utils.py
+++ b/xmitgcm/utils.py
@@ -1267,7 +1267,7 @@ def get_extra_metadata(domain='llc', nx=90):
         all extra_metadata to handle multi-faceted grids
     """
 
-    available_domains = ['llc', 'aste', 'nesba', 'cs']
+    available_domains = ['llc', 'aste', 'nesba', 'aste1080', 'cs']
     if domain not in available_domains:
         raise ValueError('not an available domain')
 
@@ -1302,6 +1302,17 @@ def get_extra_metadata(domain='llc', nx=90):
             'face_offsets': [0],
             'transpose_face': [True]}
 
+    aste1080 = {'has_faces': True, 'ny': int(23*nx/6.), 'nx': nx,
+            'ny_facets': [int(7*nx/6.), 0, nx,
+                          int(nx/2.), int(7*nx/6.)],
+            'pad_before_y': [int(15*nx/18.), 0, 0, 0, 0],
+            'pad_after_y': [0, 0, 0, int(nx/2.), int(15*nx/18.)],
+            'face_facets': [0, 0, 2, 3, 4, 4],
+            'facet_orders': ['C', 'C', 'C', 'F', 'F'],
+            'face_offsets': [0, 1, 0, 0, 0, 1],
+            'transpose_face': [False, False, False,
+                               True, True, True]}
+
     cs = {'has_faces': True, 'ny': nx, 'nx': nx,
           'ny_facets': [nx, nx, nx, nx, nx, nx],
           'face_facets': [0, 1, 2, 3, 4, 5],
@@ -1316,6 +1327,8 @@ def get_extra_metadata(domain='llc', nx=90):
         extra_metadata = aste
     elif domain =='nesba':
         extra_metadata = nesba
+    elif domain == 'aste1080':
+        extra_metadata = aste1080
     elif domain == 'cs':
         extra_metadata = cs
 
@@ -1676,6 +1689,7 @@ def rebuild_llc_facets(da, extra_metadata):
 
     # if present, remove padding from facets
     for kfacet in range(nfacets):
+
         concat_dim, non_concat_dim = find_concat_dim_facet(
             da, kfacet, extra_metadata)
 

--- a/xmitgcm/utils.py
+++ b/xmitgcm/utils.py
@@ -1294,9 +1294,9 @@ def get_extra_metadata(domain='llc', nx=90):
 
     nesb = {'has_faces': True, 
             'ny': 170, 'nx': 220,
-            'ny_facets': [170],
-            'pad_before_y': [0, 0, 0, 0, 0],
-            'pad_after_y': [0, 0, 0, 0, 0],
+            'ny_facets': [0,0,0,0,170],
+            'pad_before_y': [0, 0, 0, 0, 2644],
+            'pad_after_y': [0, 0, 0, 0, 1506],
             'face_facets': [4],
             'facet_orders': ['C', 'C', 'C', 'F', 'F'],
             'face_offsets': [0],

--- a/xmitgcm/utils.py
+++ b/xmitgcm/utils.py
@@ -1277,7 +1277,7 @@ def get_extra_metadata(domain='llc', nx=90):
         all extra_metadata to handle multi-faceted grids
     """
 
-    available_domains = ['llc', 'aste', 'nesb', 'aste1080', 'cs']
+    available_domains = ['llc', 'aste', 'cs']
     if domain not in available_domains:
         raise ValueError('not an available domain')
 
@@ -1302,27 +1302,6 @@ def get_extra_metadata(domain='llc', nx=90):
             'transpose_face': [False, False, False,
                                True, True, True]}
 
-    nesb = {'has_faces': False, 
-            'ny': 170, 'nx': 220,
-            'ny_facets': [0,0,0,0,170],
-            'pad_before_y': [0, 0, 0, 0, 2644],
-            'pad_after_y': [0, 0, 0, 0, 1506],
-            'face_facets': [4],
-            'facet_orders': ['C', 'C', 'C', 'F', 'F'],
-            'face_offsets': [0],
-            'transpose_face': [True]}
-
-    aste1080 = {'has_faces': True, 'ny': int(23*nx/6.), 'nx': nx,
-            'ny_facets': [int(7*nx/6.), 0, nx,
-                          int(nx/2.), int(7*nx/6.)],
-            'pad_before_y': [int(15*nx/18.), 0, 0, 0, 0],
-            'pad_after_y': [0, 0, 0, int(nx/2.), int(15*nx/18.)],
-            'face_facets': [0, 0, 2, 3, 4, 4],
-            'facet_orders': ['C', 'C', 'C', 'F', 'F'],
-            'face_offsets': [0, 1, 0, 0, 0, 1],
-            'transpose_face': [False, False, False,
-                               True, True, True]}
-
     cs = {'has_faces': True, 'ny': nx, 'nx': nx,
           'ny_facets': [nx, nx, nx, nx, nx, nx],
           'face_facets': [0, 1, 2, 3, 4, 5],
@@ -1335,10 +1314,6 @@ def get_extra_metadata(domain='llc', nx=90):
         extra_metadata = llc
     elif domain == 'aste':
         extra_metadata = aste
-    elif domain =='nesb':
-        extra_metadata = nesb
-    elif domain == 'aste1080':
-        extra_metadata = aste1080
     elif domain == 'cs':
         extra_metadata = cs
 

--- a/xmitgcm/utils.py
+++ b/xmitgcm/utils.py
@@ -1267,7 +1267,7 @@ def get_extra_metadata(domain='llc', nx=90):
         all extra_metadata to handle multi-faceted grids
     """
 
-    available_domains = ['llc', 'aste', 'nesba', 'aste1080', 'cs']
+    available_domains = ['llc', 'aste', 'nesb', 'aste1080', 'cs']
     if domain not in available_domains:
         raise ValueError('not an available domain')
 
@@ -1292,9 +1292,9 @@ def get_extra_metadata(domain='llc', nx=90):
             'transpose_face': [False, False, False,
                                True, True, True]}
 
-    nesba = {'has_faces': True, 
-            'ny': 270, 'nx': 270,
-            'ny_facets': [270],
+    nesb = {'has_faces': True, 
+            'ny': 170, 'nx': 220,
+            'ny_facets': [170],
             'pad_before_y': [0, 0, 0, 0, 0],
             'pad_after_y': [0, 0, 0, 0, 0],
             'face_facets': [4],
@@ -1325,8 +1325,8 @@ def get_extra_metadata(domain='llc', nx=90):
         extra_metadata = llc
     elif domain == 'aste':
         extra_metadata = aste
-    elif domain =='nesba':
-        extra_metadata = nesba
+    elif domain =='nesb':
+        extra_metadata = nesb
     elif domain == 'aste1080':
         extra_metadata = aste1080
     elif domain == 'cs':


### PR DESCRIPTION
Old patches used for applications of domains contained in a single face. 

Helps to:
- set `offset_vars` when `file_metadata` only has a single variable
- use `find_concat_dim_facet` if DataArray input doesn't contain a `face` dimension
- use llc regions that aren't starting on `facet0`, reads `nz` not the first facet which works in existing domains defined in fxn `get_extra_metadata`

